### PR TITLE
Fix UI extension detection in remote dev container environment

### DIFF
--- a/src/vscode-workspace-extension/src/extension.ts
+++ b/src/vscode-workspace-extension/src/extension.ts
@@ -47,22 +47,17 @@ export function activate(context: vscode.ExtensionContext): void {
 }
 
 async function injectCertificate(): Promise<void> {
-  // Check whether the UI extension is installed on the host.
-  // We intentionally do not use extensionDependencies because that
-  // prevents activation entirely when the host extension is missing,
-  // which blocks us from showing a helpful install prompt.
-  const uiExtension = vscode.extensions.getExtension(UI_EXTENSION_ID);
-  if (!uiExtension) {
-    log(`UI extension ${UI_EXTENSION_ID} not installed.`);
-    await promptInstallUiExtension();
-    return;
-  }
-
   // The UI extension declares onCommand:devcontainer-dev-certs.getCertMaterial
   // as an activation event, so executeCommand will trigger its activation and
   // wait for the command handler to be registered before executing.
+  //
+  // We do not use vscode.extensions.getExtension() to pre-check installation
+  // because getExtension() only sees extensions in the same extension host.
+  // The UI extension runs in the local/UI host while this extension runs in
+  // the remote host, so getExtension() would always return undefined.
+  // Instead we call executeCommand directly and distinguish "not installed"
+  // from other errors via the rejection message.
 
-  // Retrieve certificate material from the host UI extension
   let material: CertMaterial | null;
   try {
     log("Calling getCertMaterial on UI extension...");
@@ -72,10 +67,19 @@ async function injectCertificate(): Promise<void> {
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     log(`Error retrieving certificate from host: ${message}`);
-    vscode.window.showErrorMessage(
-      "Dev Certs: Failed to generate or trust the certificate on the host machine. " +
-        "Check the Dev Container Dev Certs output on the host for details."
-    );
+
+    if (message.includes("not found")) {
+      // VS Code rejects with "command '<id>' not found" when no handler is
+      // registered, which means the host UI extension is not installed.
+      log(`UI extension ${UI_EXTENSION_ID} not installed.`);
+      await promptInstallUiExtension();
+    } else {
+      // The UI extension is installed but threw an error during execution.
+      vscode.window.showErrorMessage(
+        "Dev Certs: Failed to generate or trust the certificate on the host machine. " +
+          "Check the Dev Container Dev Certs output on the host for details."
+      );
+    }
     return;
   }
 

--- a/src/vscode-workspace-extension/src/extension.ts
+++ b/src/vscode-workspace-extension/src/extension.ts
@@ -68,7 +68,7 @@ async function injectCertificate(): Promise<void> {
     const message = err instanceof Error ? err.message : String(err);
     log(`Error retrieving certificate from host: ${message}`);
 
-    if (message.includes("not found")) {
+    if (message.includes(`command '${GET_CERT_COMMAND}' not found`)) {
       // VS Code rejects with "command '<id>' not found" when no handler is
       // registered, which means the host UI extension is not installed.
       log(`UI extension ${UI_EXTENSION_ID} not installed.`);


### PR DESCRIPTION
## Summary
This change fixes the certificate injection logic to properly detect whether the UI extension is installed when running in a remote dev container environment. The previous approach of using `vscode.extensions.getExtension()` doesn't work across different extension hosts (remote vs. local/UI), so the code now relies on command execution and error handling instead.

## Key Changes
- Removed the pre-check using `vscode.extensions.getExtension()` which always returned undefined in remote contexts
- Changed the approach to call `executeCommand()` directly and distinguish between "extension not installed" and other errors based on the rejection message
- Added logic to detect the "not found" error message which indicates the UI extension is not installed
- Separated error handling into two paths:
  - "Not found" errors trigger the install prompt (extension not installed)
  - Other errors show the existing error message (extension installed but failed)

## Implementation Details
- VS Code rejects command execution with a "command '<id>' not found" message when no handler is registered, which reliably indicates the extension is not installed
- This approach works correctly across extension hosts since `executeCommand()` can reach handlers in different hosts, unlike `getExtension()`
- The error message check uses `includes("not found")` to handle the rejection message format
- Added detailed comments explaining why the previous approach didn't work and how the new approach solves it

https://claude.ai/code/session_01MFmJnsQG85qXV5HKJrT9hw