### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -17,8 +17,8 @@ jobs:
     name: Build & Test Extensions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22"
 
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload VSIX artifacts
         if: inputs.upload-vsix
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vsix
           path: src/vscode-*-extension/*.vsix
@@ -54,8 +54,8 @@ jobs:
     name: Validate Devcontainer Feature
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22"
 

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -14,7 +14,7 @@ jobs:
     name: Create version bump PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
 
@@ -29,7 +29,7 @@ jobs:
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"
           echo "Released $TAG → next dev version: $NEXT"
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
 


### PR DESCRIPTION
## Summary
This PR updates GitHub Actions dependencies to their latest versions across all workflow files to improve security, performance, and access to new features.

## Key Changes
- **actions/checkout**: Updated from v4.3.1 to v6.0.2
- **actions/setup-node**: Updated from v4.4.0 to v6.3.0
- **actions/upload-artifact**: Updated from v4.6.2 to v7.0.1

These updates are applied consistently across the following workflows:
- `.github/workflows/build-extensions.yml` (3 action updates)
- `.github/workflows/bump-version.yml` (2 action updates)

## Implementation Details
All action versions have been updated to their latest stable releases with corresponding commit SHAs pinned for reproducibility and security. The Node.js version remains at 22 as specified in the workflow configurations.

https://claude.ai/code/session_01E1bwdpEvpYeqWos37J1EFa