### PR TITLE
Add .NET Root store support for certificate trust verification

### DIFF
--- a/src/devcontainer-feature/src/devcontainer-dev-certs/install.sh
+++ b/src/devcontainer-feature/src/devcontainer-dev-certs/install.sh
@@ -30,6 +30,11 @@ fi
 DOTNET_STORE_DIR="${REMOTE_USER_HOME}/.dotnet/corefx/cryptography/x509stores/my"
 mkdir -p "${DOTNET_STORE_DIR}"
 
+# Create .NET X509Store CurrentUser\Root directory
+# The .NET runtime checks this store to determine whether a certificate is trusted
+DOTNET_ROOT_STORE_DIR="${REMOTE_USER_HOME}/.dotnet/corefx/cryptography/x509stores/root"
+mkdir -p "${DOTNET_ROOT_STORE_DIR}"
+
 # Create OpenSSL trust directory
 # PEM certs + hash symlinks go here; SSL_CERT_DIR includes this path
 TRUST_DIR="${REMOTE_USER_HOME}/.aspnet/dev-certs/trust"
@@ -51,5 +56,6 @@ if id "${REMOTE_USER}" &>/dev/null; then
 fi
 
 echo "Dev certificate infrastructure ready."
-echo "  .NET cert store: ${DOTNET_STORE_DIR}"
-echo "  OpenSSL trust:   ${TRUST_DIR}"
+echo "  .NET cert store:      ${DOTNET_STORE_DIR}"
+echo "  .NET root store:      ${DOTNET_ROOT_STORE_DIR}"
+echo "  OpenSSL trust:        ${TRUST_DIR}"

--- a/src/devcontainer-feature/src/devcontainer-dev-certs/scripts/setup-cert.sh
+++ b/src/devcontainer-feature/src/devcontainer-dev-certs/scripts/setup-cert.sh
@@ -15,12 +15,23 @@ REMOTE_USER="${_REMOTE_USER:-vscode}"
 REMOTE_USER_HOME="${_REMOTE_USER_HOME:-/home/${REMOTE_USER}}"
 
 DOTNET_STORE_DIR="${REMOTE_USER_HOME}/.dotnet/corefx/cryptography/x509stores/my"
+DOTNET_ROOT_STORE_DIR="${REMOTE_USER_HOME}/.dotnet/corefx/cryptography/x509stores/root"
 TRUST_DIR="${REMOTE_USER_HOME}/.aspnet/dev-certs/trust"
 
 # Copy PFX to .NET store
 mkdir -p "${DOTNET_STORE_DIR}"
 cp "${PFX_PATH}" "${DOTNET_STORE_DIR}/${THUMBPRINT}.pfx"
 chmod 600 "${DOTNET_STORE_DIR}/${THUMBPRINT}.pfx"
+
+# Create public-cert-only PFX for .NET Root store (trust verification)
+mkdir -p "${DOTNET_ROOT_STORE_DIR}"
+if command -v openssl &>/dev/null; then
+    openssl pkcs12 -export -in "${PEM_PATH}" -nokeys -passout pass: \
+        -out "${DOTNET_ROOT_STORE_DIR}/${THUMBPRINT}.pfx"
+    chmod 644 "${DOTNET_ROOT_STORE_DIR}/${THUMBPRINT}.pfx"
+else
+    echo "Warning: openssl not found. Root store PFX not created. Certificate may not be reported as trusted by dotnet."
+fi
 
 # Copy PEM to trust directory
 mkdir -p "${TRUST_DIR}"
@@ -53,5 +64,6 @@ if id "${REMOTE_USER}" &>/dev/null; then
 fi
 
 echo "Certificate installed."
-echo "  .NET store: ${DOTNET_STORE_DIR}/${THUMBPRINT}.pfx"
-echo "  OpenSSL trust: ${TRUST_DIR}/${PEM_FILENAME}"
+echo "  .NET store:      ${DOTNET_STORE_DIR}/${THUMBPRINT}.pfx"
+echo "  .NET root store: ${DOTNET_ROOT_STORE_DIR}/${THUMBPRINT}.pfx"
+echo "  OpenSSL trust:   ${TRUST_DIR}/${PEM_FILENAME}"

--- a/src/shared/src/index.ts
+++ b/src/shared/src/index.ts
@@ -2,6 +2,7 @@ export { initLogger, log } from "./logger";
 export type { CertMaterial } from "./types";
 export {
   getDotNetStorePath,
+  getDotNetRootStorePath,
   getOpenSslTrustDir,
   getPfxFileName,
   getPemFileName,

--- a/src/shared/src/paths.ts
+++ b/src/shared/src/paths.ts
@@ -17,6 +17,23 @@ export function getDotNetStorePath(): string {
 }
 
 /**
+ * .NET X509Store CurrentUser\Root path on Linux.
+ * The .NET runtime checks this store to determine whether a certificate is trusted.
+ * Writing the dev cert here (as a public-cert-only PFX) causes dotnet to report it
+ * as "trusted", matching the behavior of `dotnet dev-certs https --trust`.
+ */
+export function getDotNetRootStorePath(): string {
+  return path.join(
+    os.homedir(),
+    ".dotnet",
+    "corefx",
+    "cryptography",
+    "x509stores",
+    "root"
+  );
+}
+
+/**
  * OpenSSL trust directory for dev certs.
  * Honors DOTNET_DEV_CERTS_OPENSSL_CERTIFICATE_DIRECTORY if set,
  * matching the behavior of .NET's UnixCertificateManager.

--- a/src/shared/src/types.ts
+++ b/src/shared/src/types.ts
@@ -7,4 +7,6 @@ export interface CertMaterial {
   pfxBase64: string;
   pemCertBase64: string;
   pemKeyBase64: string;
+  /** Public-cert-only PFX for the .NET Root store (no private key). */
+  rootPfxBase64: string;
 }

--- a/src/vscode-ui-extension/src/cert/exporter.ts
+++ b/src/vscode-ui-extension/src/cert/exporter.ts
@@ -68,3 +68,26 @@ export function certToDer(cert: forge.pki.Certificate): Buffer {
   const derBytes = forge.asn1.toDer(forge.pki.certificateToAsn1(cert));
   return Buffer.from(derBytes.getBytes(), "binary");
 }
+
+/**
+ * Export a public-cert-only PFX for the .NET Root store.
+ * This matches what `dotnet dev-certs https --trust` writes to
+ * ~/.dotnet/corefx/cryptography/x509stores/root/ on Linux.
+ */
+export function exportRootPfx(
+  cert: forge.pki.Certificate,
+  outputDir: string
+): string {
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const p12Asn1 = forge.pkcs12.toPkcs12Asn1(
+    null as unknown as forge.pki.rsa.PrivateKey,
+    [cert],
+    "",
+    { algorithm: "3des" }
+  );
+  const p12Der = forge.asn1.toDer(p12Asn1).getBytes();
+  const outPath = path.join(outputDir, "aspnetcore-dev-root.pfx");
+  fs.writeFileSync(outPath, Buffer.from(p12Der, "binary"));
+  return outPath;
+}

--- a/src/vscode-ui-extension/src/cert/manager.ts
+++ b/src/vscode-ui-extension/src/cert/manager.ts
@@ -1,6 +1,6 @@
 import * as forge from "node-forge";
 import { generateCertificate, GeneratedCert } from "./generator";
-import { exportPfx, exportPem } from "./exporter";
+import { exportPfx, exportPem, exportRootPfx } from "./exporter";
 import { VALIDITY_DAYS } from "./properties";
 import {
   PlatformCertificateStore,
@@ -89,7 +89,7 @@ export class CertManager {
    * Export the current cert in the specified format.
    */
   async exportCert(
-    format: "pfx" | "pem",
+    format: "pfx" | "pem" | "root-pfx",
     outputDir: string,
     password?: string
   ): Promise<void> {
@@ -102,6 +102,8 @@ export class CertManager {
         outputDir,
         password
       );
+    } else if (format === "root-pfx") {
+      exportRootPfx(this.currentCert!.cert, outputDir);
     } else {
       exportPem(this.currentCert!.cert, this.currentCert!.key, outputDir);
     }

--- a/src/vscode-ui-extension/src/certProvider.ts
+++ b/src/vscode-ui-extension/src/certProvider.ts
@@ -50,10 +50,12 @@ export class CertProvider {
     try {
       await this.certManager.exportCert("pfx", tmpDir);
       await this.certManager.exportCert("pem", tmpDir);
+      await this.certManager.exportCert("root-pfx", tmpDir);
 
       const pfxPath = path.join(tmpDir, "aspnetcore-dev.pfx");
       const pemCertPath = path.join(tmpDir, "aspnetcore-dev.pem");
       const pemKeyPath = path.join(tmpDir, "aspnetcore-dev.key");
+      const rootPfxPath = path.join(tmpDir, "aspnetcore-dev-root.pfx");
 
       const updatedStatus = await this.certManager.check();
 
@@ -62,6 +64,7 @@ export class CertProvider {
         pfxBase64: fs.readFileSync(pfxPath).toString("base64"),
         pemCertBase64: fs.readFileSync(pemCertPath).toString("base64"),
         pemKeyBase64: fs.readFileSync(pemKeyPath).toString("base64"),
+        rootPfxBase64: fs.readFileSync(rootPfxPath).toString("base64"),
       };
 
       this.cached = material;

--- a/src/vscode-ui-extension/src/platform/linuxStore.ts
+++ b/src/vscode-ui-extension/src/platform/linuxStore.ts
@@ -8,6 +8,7 @@ import { ASPNET_HTTPS_OID } from "../cert/properties";
 import { certToPem } from "../cert/exporter";
 import {
   getDotNetStorePath,
+  getDotNetRootStorePath,
   getOpenSslTrustDir,
   getPemFileName,
 } from "@devcontainer-dev-certs/shared";
@@ -24,9 +25,8 @@ import {
  * 2. Writing a PEM to the OpenSSL trust directory with hash symlinks (for OpenSSL/curl/etc.)
  */
 export class LinuxCertificateStore extends BaseCertificateStore {
-  /** .NET Root store is the sibling "root" directory next to "my" */
   private get dotNetRootStorePath(): string {
-    return path.resolve(getDotNetStorePath(), "..", "root");
+    return getDotNetRootStorePath();
   }
 
   async findExistingDevCert(): Promise<{

--- a/src/vscode-ui-extension/tests/linuxStore.test.ts
+++ b/src/vscode-ui-extension/tests/linuxStore.test.ts
@@ -17,6 +17,7 @@ vi.mock("../src/platform/processUtil", () => ({
 
 // Mock shared paths to use temp directories
 let testStoreDir: string;
+let testRootStoreDir: string;
 let testTrustDir: string;
 
 vi.mock("@devcontainer-dev-certs/shared", async (importOriginal) => {
@@ -25,6 +26,7 @@ vi.mock("@devcontainer-dev-certs/shared", async (importOriginal) => {
   return {
     ...original,
     getDotNetStorePath: () => testStoreDir,
+    getDotNetRootStorePath: () => testRootStoreDir,
     getOpenSslTrustDir: () => testTrustDir,
   };
 });
@@ -50,6 +52,7 @@ describe("LinuxCertificateStore", () => {
     vi.clearAllMocks();
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "devcerts-test-"));
     testStoreDir = path.join(tmpDir, "x509stores", "my");
+    testRootStoreDir = path.join(tmpDir, "x509stores", "root");
     testTrustDir = path.join(tmpDir, "trust");
     store = new LinuxCertificateStore();
   });
@@ -88,7 +91,7 @@ describe("LinuxCertificateStore", () => {
       const { cert, thumbprint } = makeTestCert();
       await store.trustCertificate(cert);
 
-      const rootDir = path.resolve(testStoreDir, "..", "root");
+      const rootDir = testRootStoreDir;
       const pfxPath = path.join(rootDir, `${thumbprint}.pfx`);
       expect(fs.existsSync(pfxPath)).toBe(true);
     });
@@ -136,7 +139,7 @@ describe("LinuxCertificateStore", () => {
       const { cert, thumbprint } = makeTestCert();
       await store.trustCertificate(cert);
 
-      const rootDir = path.resolve(testStoreDir, "..", "root");
+      const rootDir = testRootStoreDir;
       const pfxPath = path.join(rootDir, `${thumbprint}.pfx`);
       const pfxBytes = fs.readFileSync(pfxPath);
       const p12Der = forge.util.createBuffer(pfxBytes.toString("binary"));
@@ -234,7 +237,7 @@ describe("LinuxCertificateStore", () => {
       await store.saveCertificate(cert, key, thumbprint);
       await store.trustCertificate(cert);
 
-      const rootDir = path.resolve(testStoreDir, "..", "root");
+      const rootDir = testRootStoreDir;
       const pfxPath = path.join(rootDir, `${thumbprint}.pfx`);
       expect(fs.existsSync(pfxPath)).toBe(true);
 

--- a/src/vscode-workspace-extension/src/certInstaller.ts
+++ b/src/vscode-workspace-extension/src/certInstaller.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import {
   getDotNetStorePath,
+  getDotNetRootStorePath,
   getOpenSslTrustDir,
   getPfxFileName,
   getPemFileName,
@@ -17,15 +18,18 @@ export function installCert(material: {
   thumbprint: string;
   pfxBase64: string;
   pemCertBase64: string;
+  rootPfxBase64: string;
 }): void {
   const dotNetStoreDir = getDotNetStorePath();
+  const dotNetRootStoreDir = getDotNetRootStorePath();
   const trustDir = getOpenSslTrustDir();
 
   // Ensure directories exist
   fs.mkdirSync(dotNetStoreDir, { recursive: true });
+  fs.mkdirSync(dotNetRootStoreDir, { recursive: true });
   fs.mkdirSync(trustDir, { recursive: true });
 
-  // 1. Write PFX to .NET cert store
+  // 1. Write PFX to .NET cert store (CurrentUser\My)
   //    Kestrel discovers this via X509Store(StoreName.My, StoreLocation.CurrentUser)
   const pfxPath = path.join(dotNetStoreDir, getPfxFileName(material.thumbprint));
   fs.writeFileSync(pfxPath, Buffer.from(material.pfxBase64, "base64"));
@@ -35,7 +39,17 @@ export function installCert(material: {
     // chmod may not be supported on all platforms
   }
 
-  // 2. Write PEM cert to OpenSSL trust directory
+  // 2. Write public-cert-only PFX to .NET Root store (CurrentUser\Root)
+  //    The .NET runtime checks this store to determine trust status.
+  const rootPfxPath = path.join(dotNetRootStoreDir, getPfxFileName(material.thumbprint));
+  fs.writeFileSync(rootPfxPath, Buffer.from(material.rootPfxBase64, "base64"));
+  try {
+    fs.chmodSync(rootPfxPath, 0o644);
+  } catch {
+    // chmod may not be supported on all platforms
+  }
+
+  // 3. Write PEM cert to OpenSSL trust directory
   const pemFileName = getPemFileName(material.thumbprint);
   const pemPath = path.join(trustDir, pemFileName);
   const pemContent = Buffer.from(material.pemCertBase64, "base64").toString(
@@ -48,7 +62,7 @@ export function installCert(material: {
     // chmod may not be supported on all platforms
   }
 
-  // 3. Create hash symlink for OpenSSL discovery
+  // 4. Create hash symlink for OpenSSL discovery
   createHashSymlink(trustDir, pemFileName, pemContent);
 }
 
@@ -60,9 +74,13 @@ export function isCertInstalled(thumbprint: string): boolean {
     getDotNetStorePath(),
     getPfxFileName(thumbprint)
   );
+  const rootPfxPath = path.join(
+    getDotNetRootStorePath(),
+    getPfxFileName(thumbprint)
+  );
   const pemPath = path.join(
     getOpenSslTrustDir(),
     getPemFileName(thumbprint)
   );
-  return fs.existsSync(pfxPath) && fs.existsSync(pemPath);
+  return fs.existsSync(pfxPath) && fs.existsSync(rootPfxPath) && fs.existsSync(pemPath);
 }


### PR DESCRIPTION
## Summary
This PR adds support for installing development certificates to the .NET Root certificate store (CurrentUser\Root), which is required for the .NET runtime to properly recognize certificates as trusted. Previously, certificates were only installed to the .NET My store and OpenSSL trust directories, but the Root store installation was missing.

## Key Changes

- **New path helper**: Added `getDotNetRootStorePath()` function to return the .NET X509Store CurrentUser\Root directory path (`~/.dotnet/corefx/cryptography/x509stores/root`)

- **Root PFX export**: Implemented `exportRootPfx()` function to create a public-cert-only PFX file (without private key) for the Root store, matching the behavior of `dotnet dev-certs https --trust`

- **Certificate installer updates**: Modified `installCert()` to:
  - Accept `rootPfxBase64` in the material object
  - Create the Root store directory
  - Write the public-cert-only PFX to the Root store
  - Updated `isCertInstalled()` to verify Root store file exists

- **Linux store integration**: Updated `LinuxCertificateStore` to use the new `getDotNetRootStorePath()` helper instead of computing the path manually

- **Setup scripts**: Enhanced both `install.sh` and `setup-cert.sh` to:
  - Create the Root store directory
  - Generate and install the public-cert-only PFX using OpenSSL
  - Updated output messages to show all three certificate locations

- **Type definitions**: Added `rootPfxBase64` field to `CertMaterial` interface with documentation

## Implementation Details

The Root store PFX is created as a public-cert-only certificate (no private key) using `forge.pkcs12.toPkcs12Asn1()` with `null` as the private key parameter. This matches the standard behavior of `dotnet dev-certs https --trust` and ensures the .NET runtime correctly identifies the certificate as trusted for HTTPS validation.

https://claude.ai/code/session_012PsGusGgx3TjR8sNrseZxg