### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -12,6 +12,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   extensions:
     name: Build & Test Extensions


### PR DESCRIPTION
Potential fix for [https://github.com/dnegstad/devcontainer-dev-certs/security/code-scanning/9](https://github.com/dnegstad/devcontainer-dev-certs/security/code-scanning/9)

Add an explicit `permissions` block with least privilege.  
Best single fix without changing behavior: set workflow-level permissions to `contents: read`, which satisfies checkout and read-only CI tasks for both jobs, including `feature`. This is the minimal safe baseline recommended by CodeQL and GitHub guidance.

Edit `.github/workflows/build-extensions.yml` near the top-level keys, inserting:

- `permissions:`
- `contents: read`

Place it after the `on:` block (or before `jobs:`), so it applies to all jobs unless overridden later.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
