### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/build-extensions.yml


### PR DESCRIPTION
Potential fix for [https://github.com/dnegstad/devcontainer-dev-certs/security/code-scanning/2](https://github.com/dnegstad/devcontainer-dev-certs/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root (best single change here), so it applies to the `build` job that calls the reusable workflow.  
A minimal least-privilege baseline for typical CI is:

- `contents: read`

This preserves existing behavior for read-only operations while preventing unnecessary write scopes on `GITHUB_TOKEN`. If the reusable workflow later requires extra scopes, those can be added explicitly and narrowly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
