### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build:
     uses: ./.github/workflows/build-extensions.yml


### PR DESCRIPTION
Potential fix for [https://github.com/dnegstad/devcontainer-dev-certs/security/code-scanning/1](https://github.com/dnegstad/devcontainer-dev-certs/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/pr.yml` so the workflow does not rely on repository defaults.  
Best minimal fix (without changing existing functionality) is to grant read-only baseline permissions:

- `contents: read`
- `packages: read`

Place this block after the trigger section (`on:`) and before `jobs:` so it applies to all jobs in this workflow, including the reusable workflow invocation job (`build`).

No imports, methods, or additional definitions are needed—this is a YAML configuration-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
