### PR TITLE
Clarify extension installation and usage in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,6 @@ No `dotnet dev-certs` commands, no manual PFX exports, no environment variable c
 - The [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension
 - Docker or a compatible container runtime
 
-### Install the Host Extension
-
-The dev container feature requests installation of the host extension automatically, but you can also install it ahead of time:
-
-- **VS Code Marketplace:** [Dev Container Dev Certificates (Host)](https://marketplace.visualstudio.com/items?itemName=dnegstad.devcontainer-dev-certs-host)
-- **Extensions view:** search for `dnegstad.devcontainer-dev-certs-host`
-- **CLI:** `code --install-extension dnegstad.devcontainer-dev-certs-host`
-
-The remote extension (`dnegstad.devcontainer-dev-certs-remote`) is installed inside the container automatically by the feature and does not need manual installation.
-
 ### Add the Feature
 
 Add the dev container feature to your project's `devcontainer.json`:
@@ -48,12 +38,24 @@ Add the dev container feature to your project's `devcontainer.json`:
 }
 ```
 
-Then rebuild or reopen your project in the dev container. On first use:
+Then rebuild or reopen your project in the dev container. The feature declares both companion extensions, so VS Code installs the remote extension inside the container automatically. The host extension is installed on your local VS Code automatically as well; if it isn't, the remote extension prompts you with an **Install Host Extension** button on first use.
 
-1. The host extension shows a consent prompt, then generates a development certificate and trusts it in your OS certificate store. On Windows this triggers a system dialog; on macOS the keychain may prompt for a password. This only happens once.
+On first use:
+
+1. The host extension shows a one-time consent prompt, then generates a development certificate and trusts it in your OS certificate store. On Windows this triggers a system dialog; on macOS the keychain may prompt for a password.
 2. The remote extension receives the certificate and installs it in the container's .NET X509 store and OpenSSL trust directory.
 3. ASP.NET, Aspire, and CLI tools like `curl` and `wget` trust the certificate automatically — no environment variables or manual configuration needed.
 4. Your host browser trusts the certificate on forwarded ports.
+
+### Installing the Host Extension Manually (Optional)
+
+You normally don't need to do this — the feature handles it. If you'd rather install the host extension (`dnegstad.devcontainer-dev-certs-host`) ahead of time:
+
+- **VS Code Marketplace:** [Dev Container Dev Certificates (Host)](https://marketplace.visualstudio.com/items?itemName=dnegstad.devcontainer-dev-certs-host)
+- **Extensions view:** search for `dnegstad.devcontainer-dev-certs-host`
+- **CLI:** `code --install-extension dnegstad.devcontainer-dev-certs-host`
+
+The remote extension (`dnegstad.devcontainer-dev-certs-remote`) runs inside the container and is installed by the feature. Don't install it on your local VS Code — it has no effect there.
 
 ## How It Works
 

--- a/src/vscode-ui-extension/README.md
+++ b/src/vscode-ui-extension/README.md
@@ -31,8 +31,6 @@ A Dev Container feature + two companion VS Code extensions that handle everythin
 
 ## Quick Start
 
-> **You usually don't install this extension manually.** Add the Dev Container feature described below to your project's `devcontainer.json` — the feature declares this extension, so VS Code will install it on your local machine when you open the container. If it doesn't, the remote companion extension prompts you with an **Install Host Extension** button on first use. Installing it manually from the Marketplace ahead of time is also fine.
-
 Add the Dev Container feature to your project's `devcontainer.json` (not to any extension settings):
 
 ```json

--- a/src/vscode-ui-extension/README.md
+++ b/src/vscode-ui-extension/README.md
@@ -31,7 +31,9 @@ A Dev Container feature + two companion VS Code extensions that handle everythin
 
 ## Quick Start
 
-Add the Dev Container feature to your `devcontainer.json`:
+> **You usually don't install this extension manually.** Add the Dev Container feature described below to your project's `devcontainer.json` — the feature declares this extension, so VS Code will install it on your local machine when you open the container. If it doesn't, the remote companion extension prompts you with an **Install Host Extension** button on first use. Installing it manually from the Marketplace ahead of time is also fine.
+
+Add the Dev Container feature to your project's `devcontainer.json` (not to any extension settings):
 
 ```json
 {
@@ -41,9 +43,9 @@ Add the Dev Container feature to your `devcontainer.json`:
 }
 ```
 
-That's it. The feature installs both extensions and configures the container's trust infrastructure. When you open the Dev Container in VS Code:
+The feature declares both companion extensions and configures the container's trust infrastructure. When you open the Dev Container in VS Code:
 
-1. This extension generates a dev cert on your host (if one doesn't exist) and trusts it in your OS certificate store
+1. This extension shows a one-time consent prompt, generates a dev cert on your host (if one doesn't exist), and trusts it in your OS certificate store
 2. The remote companion extension requests the cert material via VS Code's cross-host command routing
 3. The cert is installed in the container's .NET X509 store and OpenSSL trust directory
 4. ASP.NET, Aspire, and other services discover the cert automatically — no environment variables or manual configuration needed

--- a/src/vscode-workspace-extension/README.md
+++ b/src/vscode-workspace-extension/README.md
@@ -31,7 +31,9 @@ A Dev Container feature + two companion VS Code extensions that handle everythin
 
 ## Quick Start
 
-Add the Dev Container feature to your `devcontainer.json`:
+> **Don't install this extension manually on your local VS Code — it has no effect there.** This extension runs inside a Dev Container (or other remote) and is installed automatically by the Dev Container feature described below. The only thing you need to do on your local machine is install the [host companion extension](https://marketplace.visualstudio.com/items?itemName=dnegstad.devcontainer-dev-certs-host), and even that is usually handled for you by the feature.
+
+Add the Dev Container feature to your project's `devcontainer.json` (not to any extension settings):
 
 ```json
 {
@@ -41,13 +43,15 @@ Add the Dev Container feature to your `devcontainer.json`:
 }
 ```
 
-That's it. The feature installs both extensions and configures the container's trust infrastructure. When you open the Dev Container in VS Code:
+The feature declares both companion extensions and configures the container's trust infrastructure. When you open the Dev Container in VS Code:
 
-1. The host extension generates a dev cert and trusts it in the host OS certificate store
+1. The host companion extension generates a dev cert and trusts it in the host OS certificate store
 2. This extension requests the cert material via VS Code's cross-host command routing
 3. The cert is installed in the container's .NET X509 store and OpenSSL trust directory
 4. ASP.NET, Aspire, and other services discover the cert automatically — no environment variables or manual configuration needed
 5. Your host browser trusts the cert on forwarded ports
+
+If the host companion extension is missing when this extension activates, you'll see an **Install Host Extension** prompt that installs it with one click.
 
 ## What This Extension Does
 
@@ -111,4 +115,4 @@ This extension honors the following environment variables, matching the behavior
 - VS Code 1.100 or later
 - [Dev Container Dev Certificates (Host)](https://marketplace.visualstudio.com/items?itemName=dnegstad.devcontainer-dev-certs-host) installed on the local machine
 
-This extension is self-contained and does not require on any additional dependencies on your host or in the container.
+This extension is self-contained and does not require any additional dependencies on your host or in the container.


### PR DESCRIPTION
## Summary
Updated README documentation across the main project and both companion extensions to clarify the automatic installation flow and reduce confusion about manual installation requirements.

## Key Changes

- **Reorganized main README**: Moved the "Install the Host Extension" section to a new optional section at the end, emphasizing that manual installation is not required since the feature handles it automatically
- **Clarified automatic installation flow**: Updated documentation to explain that:
  - The Dev Container feature automatically declares both companion extensions
  - The host extension is installed automatically on the local VS Code
  - The remote extension is installed automatically in the container
  - A fallback "Install Host Extension" button appears if the host extension is missing
- **Updated remote extension README**: Added prominent notice that this extension should not be manually installed on local VS Code, and clarified it's installed automatically by the feature
- **Updated host extension README**: Added guidance that manual installation is optional and usually unnecessary, with clear instructions on when/how to do it manually
- **Improved clarity on configuration**: Emphasized that the Dev Container feature should be added to `devcontainer.json`, not to extension settings
- **Minor fixes**: Corrected grammar ("does not require on any" → "does not require any")

## Notable Details

The changes maintain backward compatibility while making the user experience clearer. Users who manually install extensions ahead of time will continue to work fine, but the documentation now properly sets expectations that this is optional and the feature handles everything automatically.

https://claude.ai/code/session_012yGwEjQqiLGsWGiCjJwZdj