### PR TITLE
Add Windows certificate validation coverage

### DIFF
--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -64,6 +64,32 @@ jobs:
           name: vsix
           path: src/vscode-*-extension/*.vsix
 
+  windows-certificate-validation:
+    name: Windows Certificate Validation
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "22"
+      - name: Set up .NET 10 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build UI Extension
+        run: npm run ${{ inputs.production && 'build:prod' || 'build' }} -w src/vscode-ui-extension
+
+      - name: Validate PFX with .NET and Windows CryptoAPI
+        # CurrentUser\Root and macOS trust both require interactive trust
+        # prompts, so CI validates Windows against LocalMachine stores only.
+        env:
+          DEVCERTS_WINDOWS_STORE_INTEGRATION: "1"
+        run: npm test -w src/vscode-ui-extension -- tests/dotnetPfx.integration.test.ts tests/windowsStore.integration.test.ts
+
   feature:
     name: Validate Devcontainer Feature
     runs-on: ubuntu-latest

--- a/src/vscode-ui-extension/src/platform/windowsStore.ts
+++ b/src/vscode-ui-extension/src/platform/windowsStore.ts
@@ -11,6 +11,8 @@ import { type DevCert, type DevKey } from "../cert/types";
 /** Cached PowerShell executable name — prefers pwsh (PowerShell 7+) over powershell (5.1). */
 let resolvedPwsh: string | null = null;
 
+export type WindowsStoreLocation = "CurrentUser" | "LocalMachine";
+
 async function getPowerShell(): Promise<string> {
   if (resolvedPwsh) return resolvedPwsh;
 
@@ -33,16 +35,21 @@ async function getPowerShell(): Promise<string> {
  * Prefers pwsh (PowerShell 7+) when available, falls back to powershell (5.1).
  */
 export class WindowsCertificateStore extends BaseCertificateStore {
+  constructor(private readonly storeLocation: WindowsStoreLocation = "CurrentUser") {
+    super();
+  }
+
   async findExistingDevCert(): Promise<{
     cert: DevCert;
     key: DevKey;
     thumbprint: string;
   } | null> {
-    // Use PowerShell to find dev certs in CurrentUser\My and export the best one as PFX
+    // Use PowerShell to find dev certs in the configured My store and export
+    // the best one as PFX.
     const script = `
       $ErrorActionPreference = 'Stop'
       $oid = '${ASPNET_HTTPS_OID}'
-      $certs = Get-ChildItem Cert:\\CurrentUser\\My | Where-Object {
+      $certs = Get-ChildItem Cert:\\${this.storeLocation}\\My | Where-Object {
         $_.Extensions | Where-Object { $_.Oid.Value -eq $oid }
       } | Sort-Object NotAfter -Descending
       if ($certs.Count -eq 0) { exit 1 }
@@ -94,7 +101,7 @@ export class WindowsCertificateStore extends BaseCertificateStore {
     const script =
       `$ErrorActionPreference = 'Stop'; ` +
       `$pwd = ConvertTo-SecureString -String 'import' -Force -AsPlainText; ` +
-      `Import-PfxCertificate -FilePath '${tmpPfx.replace(/'/g, "''")}' -CertStoreLocation Cert:\\CurrentUser\\My -Password $pwd -Exportable | Out-Null; ` +
+      `Import-PfxCertificate -FilePath '${tmpPfx.replace(/'/g, "''")}' -CertStoreLocation Cert:\\${this.storeLocation}\\My -Password $pwd -Exportable | Out-Null; ` +
       `Remove-Item '${tmpPfx.replace(/'/g, "''")}'`;
 
     const pwsh = await getPowerShell();
@@ -119,14 +126,15 @@ export class WindowsCertificateStore extends BaseCertificateStore {
   }
 
   async trustCertificate(cert: DevCert): Promise<void> {
-    // Export public cert as DER, import to CurrentUser\Root via X509Store API
+    // Export public cert as DER, import to the configured Root store via
+    // X509Store API.
     const tmpCert = path.join(os.tmpdir(), `devcert-trust-${Date.now()}.cer`);
     fs.writeFileSync(tmpCert, certToDer(cert));
 
     const script =
       `$ErrorActionPreference = 'Stop'; ` +
       `$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2('${tmpCert.replace(/'/g, "''")}'); ` +
-      `$store = New-Object System.Security.Cryptography.X509Certificates.X509Store('Root', 'CurrentUser'); ` +
+      `$store = New-Object System.Security.Cryptography.X509Certificates.X509Store('Root', '${this.storeLocation}'); ` +
       `$store.Open('ReadWrite'); ` +
       `$store.Add($cert); ` +
       `$store.Close(); ` +
@@ -157,7 +165,7 @@ export class WindowsCertificateStore extends BaseCertificateStore {
       $ErrorActionPreference = 'SilentlyContinue'
       $oid = '${ASPNET_HTTPS_OID}'
       foreach ($storeName in @('My', 'Root')) {
-        $store = New-Object System.Security.Cryptography.X509Certificates.X509Store($storeName, 'CurrentUser')
+        $store = New-Object System.Security.Cryptography.X509Certificates.X509Store($storeName, '${this.storeLocation}')
         $store.Open('ReadWrite')
         $toRemove = $store.Certificates | Where-Object {
           $_.Extensions | Where-Object { $_.Oid.Value -eq $oid }
@@ -183,7 +191,7 @@ export class WindowsCertificateStore extends BaseCertificateStore {
     thumbprint: string
   ): Promise<boolean> {
     const script = `
-      $cert = Get-ChildItem Cert:\\CurrentUser\\Root | Where-Object { $_.Thumbprint -eq '${thumbprint}' }
+      $cert = Get-ChildItem Cert:\\${this.storeLocation}\\Root | Where-Object { $_.Thumbprint -eq '${thumbprint}' }
       if ($cert) { Write-Output 'true' } else { Write-Output 'false' }
     `;
 

--- a/src/vscode-ui-extension/tests/dotnetPfx.integration.test.ts
+++ b/src/vscode-ui-extension/tests/dotnetPfx.integration.test.ts
@@ -101,6 +101,8 @@ describe.skipIf(!dotnetReady)(
       // .NET's X509Certificate2.Thumbprint is SHA-1 uppercase hex — the
       // exact value our generator emits as `cert.thumbprintSha1`.
       expect(parts[2], diagnostic).toBe(generated.cert.thumbprintSha1);
+      // Kestrel needs the private key attached, not just a loadable leaf cert.
+      expect(parts[3], diagnostic).toBe("True");
     }, 60_000);
   }
 );

--- a/src/vscode-ui-extension/tests/windowsStore.integration.test.ts
+++ b/src/vscode-ui-extension/tests/windowsStore.integration.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { execFileSync } from "child_process";
+import { WindowsCertificateStore } from "../src/platform/windowsStore";
+import { generateCertificate } from "../src/cert/generator";
+import { VALIDITY_DAYS } from "../src/cert/properties";
+
+const enabled =
+  process.platform === "win32" &&
+  process.env["DEVCERTS_WINDOWS_STORE_INTEGRATION"] === "1";
+
+let pwsh = "powershell";
+const importedThumbprints: string[] = [];
+
+function psString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function runPowerShell(script: string): string {
+  return execFileSync(pwsh, ["-NoProfile", "-NonInteractive", "-Command", script], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 60_000,
+  }).trim();
+}
+
+function resolvePowerShell(): string {
+  try {
+    execFileSync("pwsh", ["-NoProfile", "-NonInteractive", "-Command", "'ok'"], {
+      stdio: "ignore",
+      timeout: 10_000,
+    });
+    return "pwsh";
+  } catch {
+    return "powershell";
+  }
+}
+
+function removeLocalMachineCert(thumbprint: string): void {
+  const quotedThumbprint = psString(thumbprint);
+  runPowerShell(`
+    $ErrorActionPreference = 'SilentlyContinue'
+    foreach ($storeName in @('My', 'Root')) {
+      $store = [System.Security.Cryptography.X509Certificates.X509Store]::new($storeName, 'LocalMachine')
+      $store.Open('ReadWrite')
+      foreach ($cert in @($store.Certificates | Where-Object { $_.Thumbprint -eq ${quotedThumbprint} })) {
+        $store.Remove($cert)
+      }
+      $store.Close()
+    }
+  `);
+}
+
+async function makeTestCert(): ReturnType<typeof generateCertificate> {
+  const now = new Date();
+  const expiry = new Date(now.getTime() + VALIDITY_DAYS * 86400 * 1000);
+  return generateCertificate(now, expiry);
+}
+
+describe.skipIf(!enabled)(
+  "WindowsCertificateStore LocalMachine integration",
+  () => {
+    beforeAll(() => {
+      pwsh = resolvePowerShell();
+      const isAdmin = runPowerShell(`
+        $principal = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+        $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+      `);
+      if (isAdmin !== "True") {
+        throw new Error(
+          "DEVCERTS_WINDOWS_STORE_INTEGRATION requires an elevated Windows process for LocalMachine store writes."
+        );
+      }
+    });
+
+    afterEach(() => {
+      for (const thumbprint of importedThumbprints.splice(0)) {
+        removeLocalMachineCert(thumbprint);
+      }
+    });
+
+    it("imports the generated PFX with a private key and trusts it via LocalMachine stores", async () => {
+      const store = new WindowsCertificateStore("LocalMachine");
+      const { cert, key, thumbprint } = await makeTestCert();
+      importedThumbprints.push(thumbprint);
+
+      await store.saveCertificate(cert, key, thumbprint);
+      await store.trustCertificate(cert);
+
+      const quotedThumbprint = psString(thumbprint);
+      const hasPrivateKey = runPowerShell(`
+        $cert = Get-ChildItem Cert:\\LocalMachine\\My\\${thumbprint}
+        if (-not $cert) { throw "Missing LocalMachine\\My cert ${thumbprint}" }
+        $cert.HasPrivateKey
+      `);
+      const trusted = runPowerShell(`
+        $cert = Get-ChildItem Cert:\\LocalMachine\\Root | Where-Object { $_.Thumbprint -eq ${quotedThumbprint} }
+        if ($cert) { 'True' } else { 'False' }
+      `);
+      const status = await store.checkStatus();
+
+      expect(hasPrivateKey).toBe("True");
+      expect(trusted).toBe("True");
+      expect(status.exists).toBe(true);
+      expect(status.isTrusted).toBe(true);
+      expect(status.thumbprint).toBe(thumbprint);
+    }, 120_000);
+  }
+);

--- a/test/dotnet-pfx-roundtrip/Program.cs
+++ b/test/dotnet-pfx-roundtrip/Program.cs
@@ -1,10 +1,10 @@
 // CI harness invoked from the UI extension's vitest integration tests.
 //
 // Reads a PFX from disk, loads it via .NET's modern PKCS#12 loader, and
-// prints "OK\t{Subject}\t{Thumbprint}" on success. Anything else exits
-// non-zero with a "FAIL\t{ExceptionType}\t{Message}" line on stderr so
-// the harness driver in TypeScript can surface a useful diagnostic when
-// our PFX format drifts away from what .NET accepts.
+// prints "OK\t{Subject}\t{Thumbprint}\t{HasPrivateKey}" on success. Anything
+// else exits non-zero with a "FAIL\t{ExceptionType}\t{Message}" line on stderr
+// so the harness driver in TypeScript can surface a useful diagnostic when our
+// PFX format drifts away from what .NET accepts.
 //
 // Usage:  PfxRoundtrip <pfx-path> [password]
 //
@@ -36,7 +36,7 @@ try
         X509KeyStorageFlags.EphemeralKeySet
     );
 
-    Console.WriteLine($"OK\t{cert.Subject}\t{cert.Thumbprint}");
+    Console.WriteLine($"OK\t{cert.Subject}\t{cert.Thumbprint}\t{cert.HasPrivateKey}");
     return 0;
 }
 catch (Exception ex)


### PR DESCRIPTION
## Summary
- assert .NET PFX round-trip keeps the private key attached
- parameterize Windows cert store location while keeping CurrentUser as the default
- add gated LocalMachine Windows CryptoAPI validation and wire it into a windows-latest CI job

## Validation
- npm run lint -w src/vscode-ui-extension
- npm run build -w src/vscode-ui-extension
- npm test -w src/vscode-ui-extension
- gated LocalMachine test fails locally without elevation, as expected