### PR TITLE
Separate Windows cert validation from .NET setup

### DIFF
--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -72,23 +72,28 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22"
-      - name: Set up .NET 10 SDK
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: "10.0.x"
-
       - name: Install dependencies
         run: npm ci
 
       - name: Build UI Extension
         run: npm run ${{ inputs.production && 'build:prod' || 'build' }} -w src/vscode-ui-extension
 
-      - name: Validate PFX with .NET and Windows CryptoAPI
+      - name: Validate PFX import with Windows CryptoAPI
         # CurrentUser\Root and macOS trust both require interactive trust
         # prompts, so CI validates Windows against LocalMachine stores only.
         env:
           DEVCERTS_WINDOWS_STORE_INTEGRATION: "1"
-        run: npm test -w src/vscode-ui-extension -- tests/dotnetPfx.integration.test.ts tests/windowsStore.integration.test.ts
+        run: npm test -w src/vscode-ui-extension -- tests/windowsStore.integration.test.ts
+
+      - name: Set up .NET 10 SDK
+        # Required only by tests/dotnetPfx.integration.test.ts, which validates
+        # .NET's managed PKCS#12 loader and private-key attachment.
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Validate PFX with .NET
+        run: npm test -w src/vscode-ui-extension -- tests/dotnetPfx.integration.test.ts
 
   feature:
     name: Validate Devcontainer Feature

--- a/src/vscode-ui-extension/src/platform/windowsStore.ts
+++ b/src/vscode-ui-extension/src/platform/windowsStore.ts
@@ -126,18 +126,14 @@ export class WindowsCertificateStore extends BaseCertificateStore {
   }
 
   async trustCertificate(cert: DevCert): Promise<void> {
-    // Export public cert as DER, import to the configured Root store via
-    // X509Store API.
+    // Export public cert as DER, then import with the built-in Windows PKI
+    // cmdlet available in Windows PowerShell.
     const tmpCert = path.join(os.tmpdir(), `devcert-trust-${Date.now()}.cer`);
     fs.writeFileSync(tmpCert, certToDer(cert));
 
     const script =
       `$ErrorActionPreference = 'Stop'; ` +
-      `$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2('${tmpCert.replace(/'/g, "''")}'); ` +
-      `$store = New-Object System.Security.Cryptography.X509Certificates.X509Store('Root', '${this.storeLocation}'); ` +
-      `$store.Open('ReadWrite'); ` +
-      `$store.Add($cert); ` +
-      `$store.Close(); ` +
+      `Import-Certificate -FilePath '${tmpCert.replace(/'/g, "''")}' -CertStoreLocation Cert:\\${this.storeLocation}\\Root | Out-Null; ` +
       `Remove-Item '${tmpCert.replace(/'/g, "''")}'`;
 
     const pwsh = await getPowerShell();
@@ -164,16 +160,12 @@ export class WindowsCertificateStore extends BaseCertificateStore {
     const script = `
       $ErrorActionPreference = 'SilentlyContinue'
       $oid = '${ASPNET_HTTPS_OID}'
-      foreach ($storeName in @('My', 'Root')) {
-        $store = New-Object System.Security.Cryptography.X509Certificates.X509Store($storeName, '${this.storeLocation}')
-        $store.Open('ReadWrite')
-        $toRemove = $store.Certificates | Where-Object {
+      foreach ($storePath in @('Cert:\\${this.storeLocation}\\My', 'Cert:\\${this.storeLocation}\\Root')) {
+        Get-ChildItem $storePath | Where-Object {
           $_.Extensions | Where-Object { $_.Oid.Value -eq $oid }
+        } | ForEach-Object {
+          Remove-Item -LiteralPath $_.PSPath -Force
         }
-        foreach ($cert in $toRemove) {
-          $store.Remove($cert)
-        }
-        $store.Close()
       }
     `;
 

--- a/src/vscode-ui-extension/tests/windowsStore.integration.test.ts
+++ b/src/vscode-ui-extension/tests/windowsStore.integration.test.ts
@@ -39,13 +39,12 @@ function removeLocalMachineCert(thumbprint: string): void {
   const quotedThumbprint = psString(thumbprint);
   runPowerShell(`
     $ErrorActionPreference = 'SilentlyContinue'
-    foreach ($storeName in @('My', 'Root')) {
-      $store = [System.Security.Cryptography.X509Certificates.X509Store]::new($storeName, 'LocalMachine')
-      $store.Open('ReadWrite')
-      foreach ($cert in @($store.Certificates | Where-Object { $_.Thumbprint -eq ${quotedThumbprint} })) {
-        $store.Remove($cert)
+    foreach ($storePath in @('Cert:\\LocalMachine\\My', 'Cert:\\LocalMachine\\Root')) {
+      Get-ChildItem $storePath | Where-Object {
+        $_.Thumbprint -eq ${quotedThumbprint}
+      } | ForEach-Object {
+        Remove-Item -LiteralPath $_.PSPath -Force
       }
-      $store.Close()
     }
   `);
 }
@@ -62,8 +61,8 @@ describe.skipIf(!enabled)(
     beforeAll(() => {
       pwsh = resolvePowerShell();
       const isAdmin = runPowerShell(`
-        $principal = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
-        $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+        net session *> $null
+        if ($LASTEXITCODE -eq 0) { 'True' } else { 'False' }
       `);
       if (isAdmin !== "True") {
         throw new Error(


### PR DESCRIPTION
## Summary
- run the Windows CryptoAPI integration before installing the .NET SDK in CI
- keep the .NET PKCS#12 compatibility harness as a separate CI step
- use built-in PowerShell certificate-provider commands for Windows trust import and cleanup

## Validation
- npm run lint -w src/vscode-ui-extension
- npm run build -w src/vscode-ui-extension
- npm test -w src/vscode-ui-extension -- tests/dotnetPfx.integration.test.ts tests/windowsStore.integration.test.ts
- npm test -w src/vscode-ui-extension