### PR TITLE
Bump to 1.0.2-pre and pin feature recommendation to :1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add the devcontainer feature to your `devcontainer.json` and everything works au
 ```json
 {
     "features": {
-        "ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs:latest": {}
+        "ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs:1": {}
     }
 }
 ```
@@ -33,7 +33,7 @@ Add the dev container feature to your project's `devcontainer.json`:
 ```json
 {
     "features": {
-        "ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs:latest": {}
+        "ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs:1": {}
     }
 }
 ```
@@ -131,7 +131,7 @@ test/
 ```json
 {
     "features": {
-        "ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs": {
+        "ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs:1": {
             "trustNss": true
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7075,7 +7075,7 @@
     },
     "src/shared": {
       "name": "@devcontainer-dev-certs/shared",
-      "version": "1.0.1",
+      "version": "1.0.2-pre",
       "devDependencies": {
         "@types/vscode": "^1.100.0",
         "typescript": "^6.0.3"
@@ -7083,7 +7083,7 @@
     },
     "src/vscode-ui-extension": {
       "name": "devcontainer-dev-certs-host",
-      "version": "1.0.1",
+      "version": "1.0.2-pre",
       "license": "MIT",
       "dependencies": {
         "@devcontainer-dev-certs/shared": "*",
@@ -7106,7 +7106,7 @@
     },
     "src/vscode-workspace-extension": {
       "name": "devcontainer-dev-certs-remote",
-      "version": "1.0.1",
+      "version": "1.0.2-pre",
       "license": "MIT",
       "dependencies": {
         "@devcontainer-dev-certs/shared": "*"

--- a/src/devcontainer-feature/src/devcontainer-dev-certs/devcontainer-feature.json
+++ b/src/devcontainer-feature/src/devcontainer-dev-certs/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "devcontainer-dev-certs",
-  "version": "1.0.1",
+  "version": "1.0.2-pre",
   "name": "Dev Container Development Certificates",
   "description": "Enables trusted HTTPS in Dev Containers by preparing certificate trust infrastructure and installing companion VS Code extensions that automatically generate, trust, and transfer ASP.NET and Aspire compatible development certificates from the host machine. Add to your devcontainer.json: \"features\": { \"ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs\": {} }",
   "documentationURL": "https://github.com/dnegstad/devcontainer-dev-certs",

--- a/src/devcontainer-feature/src/devcontainer-dev-certs/devcontainer-feature.json
+++ b/src/devcontainer-feature/src/devcontainer-dev-certs/devcontainer-feature.json
@@ -2,7 +2,7 @@
   "id": "devcontainer-dev-certs",
   "version": "1.0.2-pre",
   "name": "Dev Container Development Certificates",
-  "description": "Enables trusted HTTPS in Dev Containers by preparing certificate trust infrastructure and installing companion VS Code extensions that automatically generate, trust, and transfer ASP.NET and Aspire compatible development certificates from the host machine. Add to your devcontainer.json: \"features\": { \"ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs\": {} }",
+  "description": "Enables trusted HTTPS in Dev Containers by preparing certificate trust infrastructure and installing companion VS Code extensions that automatically generate, trust, and transfer ASP.NET and Aspire compatible development certificates from the host machine. Add to your devcontainer.json: \"features\": { \"ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs:1\": {} }",
   "documentationURL": "https://github.com/dnegstad/devcontainer-dev-certs",
   "keywords": [
     "dotnet",

--- a/src/shared/package.json
+++ b/src/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devcontainer-dev-certs/shared",
-  "version": "1.0.1",
+  "version": "1.0.2-pre",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/src/vscode-ui-extension/README.md
+++ b/src/vscode-ui-extension/README.md
@@ -36,7 +36,7 @@ Add the Dev Container feature to your project's `devcontainer.json` (not to any 
 ```json
 {
     "features": {
-        "ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs": {}
+        "ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs:1": {}
     }
 }
 ```

--- a/src/vscode-ui-extension/package.json
+++ b/src/vscode-ui-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Dev Container Dev Certificates (Host)",
   "description": "Generates and trusts ASP.NET and Aspire compatible HTTPS development certificates on the host machine for use in Dev Containers and remote environments.",
   "icon": "images/dn_ui_extension_icon_256.png",
-  "version": "1.0.1",
+  "version": "1.0.2-pre",
   "publisher": "dnegstad",
   "license": "MIT",
   "repository": {

--- a/src/vscode-workspace-extension/README.md
+++ b/src/vscode-workspace-extension/README.md
@@ -38,7 +38,7 @@ Add the Dev Container feature to your project's `devcontainer.json` (not to any 
 ```json
 {
     "features": {
-        "ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs": {}
+        "ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs:1": {}
     }
 }
 ```
@@ -89,7 +89,7 @@ When using the Dev Container feature, these options are available:
 ```json
 {
     "features": {
-        "ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs": {
+        "ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs:1": {
             "trustNss": false,
             "sslCertDirs": "/etc/ssl/certs:/usr/lib/ssl/certs:/etc/pki/tls/certs:/var/lib/ca-certificates/openssl"
         }

--- a/src/vscode-workspace-extension/package.json
+++ b/src/vscode-workspace-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Dev Container Dev Certificates (Remote)",
   "description": "Receives and installs ASP.NET and Aspire compatible HTTPS development certificates inside Dev Containers and remote environments.",
   "icon": "images/dn_workspace_extension_icon_256.png",
-  "version": "1.0.1",
+  "version": "1.0.2-pre",
   "publisher": "dnegstad",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- Open the post-1.0.1 development cycle by bumping the feature manifest, all three workspace packages, and `package-lock.json` to `1.0.2-pre`.
- Update every README example (and the feature manifest `description` shown in the catalog) to pin the feature to `:1` instead of `:latest` (or unpinned, which behaves the same).

## Why

The devcontainer CLI's `:latest` resolution can lag behind the actual most-recent published release — users following the previous README guidance ended up pinned to `1.0.0` even after `1.0.1` shipped. Pinning the major-version tag `:1` moves forward with every 1.x release without exposing users to breaking changes from a future major.

## Test plan

- [x] `node test/validate-feature.mjs` — all checks pass with the bumped version.
- [ ] After merge, normal release workflow publishes `1.0.2` and updates the `:1` floating tag.

https://claude.ai/code/session_018AmRDWxPGu5bHLKYfunWMj

---
_Generated by [Claude Code](https://claude.ai/code/session_018AmRDWxPGu5bHLKYfunWMj)_