### PR TITLE
Security hardening: file permissions, temp file naming, and input validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7075,7 +7075,7 @@
     },
     "src/shared": {
       "name": "@devcontainer-dev-certs/shared",
-      "version": "1.0.3-pre",
+      "version": "1.0.3",
       "devDependencies": {
         "@types/vscode": "^1.100.0",
         "typescript": "^6.0.3"
@@ -7083,7 +7083,7 @@
     },
     "src/vscode-ui-extension": {
       "name": "devcontainer-dev-certs-host",
-      "version": "1.0.3-pre",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@devcontainer-dev-certs/shared": "*",
@@ -7106,7 +7106,7 @@
     },
     "src/vscode-workspace-extension": {
       "name": "devcontainer-dev-certs-remote",
-      "version": "1.0.3-pre",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@devcontainer-dev-certs/shared": "*"

--- a/src/devcontainer-feature/src/devcontainer-dev-certs/devcontainer-feature.json
+++ b/src/devcontainer-feature/src/devcontainer-dev-certs/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "devcontainer-dev-certs",
-  "version": "1.0.3-pre",
+  "version": "1.0.3",
   "name": "Dev Container Development Certificates",
   "description": "Enables trusted HTTPS in Dev Containers by preparing certificate trust infrastructure and installing companion VS Code extensions that automatically generate, trust, and transfer ASP.NET and Aspire compatible development certificates from the host machine. Add to your devcontainer.json: \"features\": { \"ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs:1\": {} }",
   "documentationURL": "https://github.com/dnegstad/devcontainer-dev-certs",

--- a/src/devcontainer-feature/src/devcontainer-dev-certs/install.sh
+++ b/src/devcontainer-feature/src/devcontainer-dev-certs/install.sh
@@ -13,6 +13,27 @@ REMOTE_USER_HOME="${_REMOTE_USER_HOME:-/home/${REMOTE_USER}}"
 
 echo "Setting up dev certificate infrastructure..."
 
+# Validate sslCertDirs: colon-separated absolute paths only. The value lands
+# inside an `export SSL_CERT_DIR=...` line that gets sourced at every login,
+# so command-substitution metacharacters here would execute as the shell
+# user. Reject anything that doesn't look like a plain path list.
+if ! printf '%s' "${SSL_CERT_DIRS}" | grep -qE '^/[A-Za-z0-9._/+@%-]+(:/[A-Za-z0-9._/+@%-]+)*$'; then
+    echo "Error: sslCertDirs contains unexpected characters; expected colon-separated absolute paths." >&2
+    exit 1
+fi
+
+# Validate that no feature option contains a newline. We append these to
+# /etc/environment, and an embedded newline would inject an extra env line
+# (potentially with a name the operator didn't intend).
+for varname in TRUST_NSS SSL_CERT_DIRS GENERATE_DOTNET_CERT SYNC_USER_CERTIFICATES EXTRA_CERT_DESTINATIONS; do
+    case "${!varname}" in
+        *$'\n'*)
+            echo "Error: feature option ${varname} must not contain newlines." >&2
+            exit 1
+            ;;
+    esac
+done
+
 # Install NSS tools if requested (for Chromium/Firefox trust)
 if [ "${TRUST_NSS}" = "true" ]; then
     if command -v apt-get &>/dev/null; then
@@ -82,10 +103,18 @@ fi
 # Append KEY="VALUE" to /etc/environment with proper escaping for the PAM
 # parser (pam_env): backslashes and double quotes inside the value must be
 # escaped. Always quote, even for values without special chars, so unquoted
-# spaces don't silently truncate the variable.
+# spaces don't silently truncate the variable. Reject embedded newlines —
+# pam_env is line-oriented and an injected newline would smuggle an
+# additional env assignment into the file.
 append_env() {
     local key="$1"
     local value="$2"
+    case "${value}" in
+        *$'\n'*)
+            echo "Error: refusing to write ${key} containing a newline to /etc/environment." >&2
+            exit 1
+            ;;
+    esac
     local escaped="${value//\\/\\\\}"
     escaped="${escaped//\"/\\\"}"
     echo "${key}=\"${escaped}\"" >> /etc/environment
@@ -102,6 +131,11 @@ append_env() {
 #   /etc/environment — read by pam_env on PAM-based logins (sshd); needs the
 #     resolved REMOTE_USER_HOME baked in since pam_env doesn't expand $HOME.
 PROFILE_SCRIPT="/etc/profile.d/devcontainer-dev-certs.sh"
+# $HOME is intentionally left unexpanded so each user picks up their own
+# trust directory at login. SSL_CERT_DIRS has been validated against
+# /^/[A-Za-z0-9._/+@%-]+(:/[A-Za-z0-9._/+@%-]+)*$/ above, so the only
+# remaining shell-meaningful character that can reach this line is `$`
+# (via $HOME). All other inputs are safe to embed verbatim.
 echo "export SSL_CERT_DIR=\"\$HOME/.aspnet/dev-certs/trust:${SSL_CERT_DIRS}\"" > "${PROFILE_SCRIPT}"
 chmod 0644 "${PROFILE_SCRIPT}"
 

--- a/src/devcontainer-feature/src/devcontainer-dev-certs/scripts/setup-cert.sh
+++ b/src/devcontainer-feature/src/devcontainer-dev-certs/scripts/setup-cert.sh
@@ -229,6 +229,12 @@ PFX_PATH="${1:?Usage: setup-cert.sh <pfx-path> <pem-path> <thumbprint>}"
 PEM_PATH="${2:?Usage: setup-cert.sh <pfx-path> <pem-path> <thumbprint>}"
 THUMBPRINT="${3:?Usage: setup-cert.sh <pfx-path> <pem-path> <thumbprint>}"
 
+# Both the root-store PFX conversion and the OpenSSL hash symlink need
+# `openssl`. Falling back to a warning leaves the cert partially
+# installed but the script exiting 0, which the caller has no way to
+# detect. Refuse the install up front instead.
+ensure_openssl
+
 # Copy PFX to .NET store
 mkdir -p "${DOTNET_STORE_DIR}"
 cp "${PFX_PATH}" "${DOTNET_STORE_DIR}/${THUMBPRINT}.pfx"
@@ -236,13 +242,9 @@ chmod 600 "${DOTNET_STORE_DIR}/${THUMBPRINT}.pfx"
 
 # Create public-cert-only PFX for .NET Root store (trust verification)
 mkdir -p "${DOTNET_ROOT_STORE_DIR}"
-if command -v openssl &>/dev/null; then
-    openssl pkcs12 -export -in "${PEM_PATH}" -nokeys -passout pass: \
-        -out "${DOTNET_ROOT_STORE_DIR}/${THUMBPRINT}.pfx"
-    chmod 644 "${DOTNET_ROOT_STORE_DIR}/${THUMBPRINT}.pfx"
-else
-    echo "Warning: openssl not found. Root store PFX not created. Certificate may not be reported as trusted by dotnet."
-fi
+openssl pkcs12 -export -in "${PEM_PATH}" -nokeys -passout pass: \
+    -out "${DOTNET_ROOT_STORE_DIR}/${THUMBPRINT}.pfx"
+chmod 644 "${DOTNET_ROOT_STORE_DIR}/${THUMBPRINT}.pfx"
 
 # Copy PEM to trust directory
 mkdir -p "${TRUST_DIR}"
@@ -250,23 +252,8 @@ PEM_FILENAME="aspnetcore-localhost-${THUMBPRINT}.pem"
 cp "${PEM_PATH}" "${TRUST_DIR}/${PEM_FILENAME}"
 chmod 644 "${TRUST_DIR}/${PEM_FILENAME}"
 
-# Create hash symlink (c_rehash equivalent) — requires openssl
-if command -v openssl &>/dev/null; then
-    HASH=$(openssl x509 -hash -noout -in "${TRUST_DIR}/${PEM_FILENAME}" 2>/dev/null || true)
-    if [ -n "${HASH}" ]; then
-        # Find available slot
-        for i in $(seq 0 9); do
-            LINK="${TRUST_DIR}/${HASH}.${i}"
-            if [ ! -e "${LINK}" ]; then
-                ln -sf "${PEM_FILENAME}" "${LINK}"
-                break
-            fi
-        done
-    fi
-else
-    echo "Warning: openssl not found. Hash symlinks not created. OpenSSL trust may not work."
-    echo "Install openssl or use the VSCode extension which handles this natively."
-fi
+# Create hash symlink (c_rehash equivalent).
+create_hash_symlink "${TRUST_DIR}" "${PEM_FILENAME}"
 
 # Fix ownership
 if id "${REMOTE_USER}" &>/dev/null; then

--- a/src/shared/package.json
+++ b/src/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devcontainer-dev-certs/shared",
-  "version": "1.0.3-pre",
+  "version": "1.0.3",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/src/vscode-ui-extension/package.json
+++ b/src/vscode-ui-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Dev Container Dev Certificates (Host)",
   "description": "Generates and trusts ASP.NET and Aspire compatible HTTPS development certificates on the host machine for use in Dev Containers and remote environments.",
   "icon": "images/dn_ui_extension_icon_256.png",
-  "version": "1.0.3-pre",
+  "version": "1.0.3",
   "publisher": "dnegstad",
   "license": "MIT",
   "repository": {

--- a/src/vscode-ui-extension/src/cert/exporter.ts
+++ b/src/vscode-ui-extension/src/cert/exporter.ts
@@ -5,6 +5,12 @@ import { type DevCert, type DevKey } from "./types";
 import { ASPNET_HTTPS_OID_FRIENDLY_NAME } from "./properties";
 import { buildPfx } from "./pfx";
 
+// PFX and unencrypted key PEM contain private key material. Use mode 0o600 on
+// every write — the temp dir created upstream is already mkdtemp'd 0o700, but
+// explicit file modes survive being copied or extracted elsewhere.
+const PRIVATE_FILE_MODE = 0o600;
+const PUBLIC_FILE_MODE = 0o644;
+
 /**
  * Export a certificate with its private key as a PFX/PKCS12 file.
  */
@@ -22,7 +28,7 @@ export async function exportPfx(
     friendlyName: ASPNET_HTTPS_OID_FRIENDLY_NAME,
   });
   const outPath = path.join(outputDir, "aspnetcore-dev.pfx");
-  fs.writeFileSync(outPath, der);
+  fs.writeFileSync(outPath, der, { mode: PRIVATE_FILE_MODE });
   return outPath;
 }
 
@@ -40,8 +46,8 @@ export function exportPem(
   const certPath = path.join(outputDir, "aspnetcore-dev.pem");
   const keyPath = path.join(outputDir, "aspnetcore-dev.key");
 
-  fs.writeFileSync(certPath, cert.pem);
-  fs.writeFileSync(keyPath, key.pem);
+  fs.writeFileSync(certPath, cert.pem, { mode: PUBLIC_FILE_MODE });
+  fs.writeFileSync(keyPath, key.pem, { mode: PRIVATE_FILE_MODE });
 
   return { certPath, keyPath };
 }
@@ -79,7 +85,7 @@ export async function exportRootPfx(
   fs.mkdirSync(outputDir, { recursive: true });
   const der = await buildPfx({ cert });
   const outPath = path.join(outputDir, "aspnetcore-dev-root.pfx");
-  fs.writeFileSync(outPath, der);
+  fs.writeFileSync(outPath, der, { mode: PUBLIC_FILE_MODE });
   return outPath;
 }
 
@@ -105,27 +111,27 @@ export async function exportLoadedCert(
   fs.mkdirSync(outputDir, { recursive: true });
 
   const pemCertPath = path.join(outputDir, `${name}.pem`);
-  fs.writeFileSync(pemCertPath, loaded.cert.pem);
+  fs.writeFileSync(pemCertPath, loaded.cert.pem, { mode: PUBLIC_FILE_MODE });
 
   let pemKeyPath: string | null = null;
   let pfxPath: string | null = null;
   if (loaded.key) {
     pemKeyPath = path.join(outputDir, `${name}.key`);
-    fs.writeFileSync(pemKeyPath, loaded.key.pem);
+    fs.writeFileSync(pemKeyPath, loaded.key.pem, { mode: PRIVATE_FILE_MODE });
 
     const pfxBytes = await buildPfx({
       cert: loaded.cert,
       key: loaded.key,
     });
     pfxPath = path.join(outputDir, `${name}.pfx`);
-    fs.writeFileSync(pfxPath, pfxBytes);
+    fs.writeFileSync(pfxPath, pfxBytes, { mode: PRIVATE_FILE_MODE });
   }
 
   let rootPfxPath: string | null = null;
   if (options.includeRootPfx) {
     const rootBytes = await buildPfx({ cert: loaded.cert });
     rootPfxPath = path.join(outputDir, `${name}-root.pfx`);
-    fs.writeFileSync(rootPfxPath, rootBytes);
+    fs.writeFileSync(rootPfxPath, rootBytes, { mode: PUBLIC_FILE_MODE });
   }
 
   return { pemCertPath, pemKeyPath, pfxPath, rootPfxPath };

--- a/src/vscode-ui-extension/src/certProvider.ts
+++ b/src/vscode-ui-extension/src/certProvider.ts
@@ -140,11 +140,10 @@ export class CertProvider {
       await this.certManager.trust();
     }
 
-    const tmpDir = path.join(
-      os.tmpdir(),
-      `devcerts-export-${Date.now()}`
-    );
-    fs.mkdirSync(tmpDir, { recursive: true });
+    // mkdtempSync gives us a unique 0o700 dir in tmpdir. Combined with
+    // 0o600 modes on the key/PFX writes themselves, the unencrypted key
+    // material is never readable by other local users while it's on disk.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "devcerts-export-"));
 
     try {
       await this.certManager.exportCert("pfx", tmpDir);
@@ -212,11 +211,10 @@ export class CertProvider {
 
     const trustInContainer = config.trustInContainer !== false;
 
-    const tmpDir = path.join(
-      os.tmpdir(),
-      `devcerts-user-export-${Date.now()}-${config.name}`
+    // Per-cert isolated 0o700 temp dir; name embedded for debuggability.
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), `devcerts-user-export-${config.name}-`)
     );
-    fs.mkdirSync(tmpDir, { recursive: true });
 
     try {
       const exported = await exportLoadedCert(loaded, config.name, tmpDir, {

--- a/src/vscode-ui-extension/src/platform/linuxStore.ts
+++ b/src/vscode-ui-extension/src/platform/linuxStore.ts
@@ -111,6 +111,24 @@ export class LinuxCertificateStore extends BaseCertificateStore {
     const pemFileName = getPemFileName(thumbprint);
     const pemPath = path.join(trustDir, pemFileName);
 
+    // Sweep PEMs from any previous dev cert rotation. Otherwise the old
+    // file lingers in the trust dir, gets a hash symlink during rehash,
+    // and OpenSSL clients keep trusting the prior (potentially expired
+    // or revoked) cert alongside the new one.
+    for (const entry of fs.readdirSync(trustDir)) {
+      if (
+        entry.startsWith("aspnetcore-localhost-") &&
+        entry.endsWith(".pem") &&
+        entry !== pemFileName
+      ) {
+        try {
+          fs.unlinkSync(path.join(trustDir, entry));
+        } catch {
+          // Best effort — a concurrent install may have removed it.
+        }
+      }
+    }
+
     fs.writeFileSync(pemPath, cert.pem, { mode: 0o644 });
     await this.rehashDirectory(trustDir);
   }
@@ -148,11 +166,17 @@ export class LinuxCertificateStore extends BaseCertificateStore {
       const hash = await this.getOpenSslSubjectHash(fullPath);
       if (!hash) continue;
 
+      // Slot 0-9 covers any realistic collision count. Catch EEXIST so a
+      // concurrent rehash can't crash this one mid-loop.
       for (let i = 0; i < 10; i++) {
         const linkPath = path.join(directory, `${hash}.${i}`);
-        if (!fs.existsSync(linkPath)) {
+        if (fs.existsSync(linkPath)) continue;
+        try {
           fs.symlinkSync(certFile, linkPath);
           break;
+        } catch (err: unknown) {
+          if ((err as NodeJS.ErrnoException).code === "EEXIST") continue;
+          throw err;
         }
       }
     }
@@ -193,3 +217,4 @@ export class LinuxCertificateStore extends BaseCertificateStore {
 function isHashSymlink(filename: string): boolean {
   return /^[0-9a-f]{8}\.\d+$/.test(filename);
 }
+

--- a/src/vscode-ui-extension/src/platform/macStore.ts
+++ b/src/vscode-ui-extension/src/platform/macStore.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -5,6 +6,7 @@ import { BaseCertificateStore } from "./baseStore";
 import { runProcess } from "./processUtil";
 import { isValidDevCert } from "../cert/generator";
 import { certToDer } from "../cert/exporter";
+import { ASPNET_HTTPS_OID } from "../cert/properties";
 import { type DevCert, type DevKey } from "../cert/types";
 
 /**
@@ -63,11 +65,15 @@ export class MacCertificateStore extends BaseCertificateStore {
       this.devCertsDir,
       `aspnetcore-localhost-${thumbprint}.pfx`
     );
-    await this.writePfx(cert, key, pfxPath);
+    // ~/.aspnet/dev-certs/https/*.pfx contains the private key; force 0o600
+    // so it can't be read by other users on a multi-user mac.
+    await this.writePfx(cert, key, pfxPath, "", 0o600);
   }
 
   async trustCertificate(cert: DevCert): Promise<void> {
-    const tmpCert = path.join(os.tmpdir(), `devcert-trust-${Date.now()}.cer`);
+    // /tmp is shared on macOS; an unguessable filename rules out symlink
+    // races on the temporary public-cert artifact.
+    const tmpCert = path.join(os.tmpdir(), `devcert-trust-${randomUUID()}.cer`);
     fs.writeFileSync(tmpCert, certToDer(cert));
 
     const result = await runProcess("security", [
@@ -95,18 +101,45 @@ export class MacCertificateStore extends BaseCertificateStore {
   }
 
   async removeCertificates(): Promise<void> {
-    // Remove trust entries from keychain (loop because there may be multiple)
-    for (let i = 0; i < 10; i++) {
-      const result = await runProcess("security", [
-        "delete-certificate",
-        "-c",
-        "localhost",
-        this.keychainPath,
-      ]);
-      if (result.exitCode !== 0) break;
+    // Collect SHA-1 thumbprints of every dev cert we have on disk so we
+    // can delete keychain entries by hash. Matching on `-c localhost` is
+    // too broad — the user may have unrelated `localhost` certs added
+    // for other tools and we don't want to nuke those.
+    const thumbprints = new Set<string>();
+    if (fs.existsSync(this.devCertsDir)) {
+      const pfxFiles = fs
+        .readdirSync(this.devCertsDir)
+        .filter(
+          (f) => f.startsWith("aspnetcore-localhost-") && f.endsWith(".pfx")
+        );
+      for (const pfxFile of pfxFiles) {
+        try {
+          const result = await this.loadPfx(path.join(this.devCertsDir, pfxFile));
+          if (result && result.cert.hasExtension(ASPNET_HTTPS_OID)) {
+            thumbprints.add(result.thumbprint);
+          }
+        } catch {
+          // Skip unparseable files; they're not ours to delete by hash.
+        }
+      }
     }
 
-    // Remove trust settings
+    for (const thumbprint of thumbprints) {
+      // delete-certificate exits non-zero once there are no more entries
+      // matching the hash; loop with a generous bound to drain any
+      // duplicates left by past regenerations.
+      for (let i = 0; i < 100; i++) {
+        const result = await runProcess("security", [
+          "delete-certificate",
+          "-Z",
+          thumbprint,
+          this.keychainPath,
+        ]);
+        if (result.exitCode !== 0) break;
+      }
+    }
+
+    // Remove trust settings entries that pointed at any of those certs.
     await runProcess("security", [
       "remove-trusted-cert",
       "-d",
@@ -130,7 +163,7 @@ export class MacCertificateStore extends BaseCertificateStore {
     cert: DevCert,
     _thumbprint: string
   ): Promise<boolean> {
-    const tmpCert = path.join(os.tmpdir(), `devcert-verify-${Date.now()}.cer`);
+    const tmpCert = path.join(os.tmpdir(), `devcert-verify-${randomUUID()}.cer`);
     try {
       fs.writeFileSync(tmpCert, certToDer(cert));
 

--- a/src/vscode-ui-extension/src/platform/windowsStore.ts
+++ b/src/vscode-ui-extension/src/platform/windowsStore.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -95,8 +96,10 @@ export class WindowsCertificateStore extends BaseCertificateStore {
     // Export to temp PFX, then import via Import-PfxCertificate. Our
     // hand-rolled DER PFX writer (cert/pfx.ts) emits a PFX that CryptoAPI's
     // PFXImportCertStore — the function this cmdlet wraps — accepts cleanly.
-    const tmpPfx = path.join(os.tmpdir(), `devcert-save-${Date.now()}.pfx`);
-    await this.writePfx(cert, key, tmpPfx, "import");
+    // Unguessable filename + 0o600 keeps the PFX (with private key)
+    // unreadable to other local users during the import window.
+    const tmpPfx = path.join(os.tmpdir(), `devcert-save-${randomUUID()}.pfx`);
+    await this.writePfx(cert, key, tmpPfx, "import", 0o600);
 
     const script =
       `$ErrorActionPreference = 'Stop'; ` +
@@ -128,7 +131,9 @@ export class WindowsCertificateStore extends BaseCertificateStore {
   async trustCertificate(cert: DevCert): Promise<void> {
     // Export public cert as DER, then import with the built-in Windows PKI
     // cmdlet available in Windows PowerShell.
-    const tmpCert = path.join(os.tmpdir(), `devcert-trust-${Date.now()}.cer`);
+    // Public-cert only — no private key — but the random name still prevents
+    // concurrent invocations from colliding on the same temp path.
+    const tmpCert = path.join(os.tmpdir(), `devcert-trust-${randomUUID()}.cer`);
     fs.writeFileSync(tmpCert, certToDer(cert));
 
     const script =

--- a/src/vscode-ui-extension/tests/linuxStore.test.ts
+++ b/src/vscode-ui-extension/tests/linuxStore.test.ts
@@ -132,6 +132,25 @@ describe("LinuxCertificateStore", () => {
       );
     });
 
+    it("sweeps stale aspnetcore-localhost-*.pem from a previous rotation", async () => {
+      // Plant a stale dev-cert PEM with a different thumbprint.
+      fs.mkdirSync(testTrustDir, { recursive: true });
+      const stalePem = path.join(
+        testTrustDir,
+        "aspnetcore-localhost-OLDTHUMBPRINT.pem"
+      );
+      fs.writeFileSync(
+        stalePem,
+        "-----BEGIN CERTIFICATE-----\nstale\n-----END CERTIFICATE-----\n"
+      );
+      expect(fs.existsSync(stalePem)).toBe(true);
+
+      const { cert } = await makeTestCert();
+      await store.trustCertificate(cert);
+
+      expect(fs.existsSync(stalePem)).toBe(false);
+    });
+
     it("root store PFX contains only the public cert (no private key)", async () => {
       const { cert, thumbprint } = await makeTestCert();
       await store.trustCertificate(cert);

--- a/src/vscode-workspace-extension/package.json
+++ b/src/vscode-workspace-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Dev Container Dev Certificates (Remote)",
   "description": "Receives and installs ASP.NET and Aspire compatible HTTPS development certificates inside Dev Containers and remote environments.",
   "icon": "images/dn_workspace_extension_icon_256.png",
-  "version": "1.0.3-pre",
+  "version": "1.0.3",
   "publisher": "dnegstad",
   "license": "MIT",
   "repository": {

--- a/src/vscode-workspace-extension/src/certInstaller.ts
+++ b/src/vscode-workspace-extension/src/certInstaller.ts
@@ -64,9 +64,32 @@ export function installDotNetDevCert(material: CertMaterialV2): void {
   const pemContent = Buffer.from(material.pemCertBase64, "base64").toString(
     "utf-8"
   );
+
+  // Remove any stale dev-cert PEM from a prior rotation. Without this
+  // sweep, the previous `aspnetcore-localhost-{oldThumb}.pem` lingers in
+  // the trust dir and OpenSSL clients (curl, Kestrel) keep trusting it
+  // alongside the freshly installed cert.
+  for (const entry of fs.readdirSync(trustDir)) {
+    if (
+      entry.startsWith("aspnetcore-localhost-") &&
+      entry.endsWith(".pem") &&
+      entry !== pemFileName
+    ) {
+      try {
+        fs.unlinkSync(path.join(trustDir, entry));
+      } catch {
+        // Best-effort.
+      }
+    }
+  }
+
   fs.writeFileSync(pemPath, pemContent);
   chmodSafe(pemPath, 0o644);
 
+  // Drop dangling hash symlinks left over by the removed PEMs, then
+  // create a fresh symlink for the new file. rehashDirectory is cheap
+  // and idempotent on a directory this small.
+  rehashDirectory(trustDir);
   createHashSymlink(trustDir, pemFileName, pemContent);
 }
 

--- a/src/vscode-workspace-extension/src/util/rehash.ts
+++ b/src/vscode-workspace-extension/src/util/rehash.ts
@@ -63,15 +63,7 @@ export function rehashDirectory(directory: string): void {
     const hash = computeSubjectHash(pemContent);
     if (!hash) continue;
 
-    // Find available slot
-    for (let i = 0; i < 10; i++) {
-      const linkName = `${hash}.${i}`;
-      const linkPath = path.join(directory, linkName);
-      if (!fs.existsSync(linkPath)) {
-        fs.symlinkSync(certFile, linkPath);
-        break;
-      }
-    }
+    createHashSymlinkForHash(directory, certFile, hash);
   }
 }
 
@@ -85,13 +77,27 @@ export function createHashSymlink(
 ): void {
   const hash = computeSubjectHash(pemContent);
   if (!hash) return;
+  createHashSymlinkForHash(directory, pemFileName, hash);
+}
 
+function createHashSymlinkForHash(
+  directory: string,
+  pemFileName: string,
+  hash: string
+): void {
+  // Slot 0-9 covers any realistic number of collisions in a dev trust dir.
+  // Catch EEXIST so a concurrent rehash from another process doesn't crash
+  // the caller — existsSync()/symlinkSync() isn't atomic on its own.
   for (let i = 0; i < 10; i++) {
     const linkName = `${hash}.${i}`;
     const linkPath = path.join(directory, linkName);
-    if (!fs.existsSync(linkPath)) {
+    if (fs.existsSync(linkPath)) continue;
+    try {
       fs.symlinkSync(pemFileName, linkPath);
-      break;
+      return;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === "EEXIST") continue;
+      throw err;
     }
   }
 }

--- a/src/vscode-workspace-extension/src/util/sslCertDir.ts
+++ b/src/vscode-workspace-extension/src/util/sslCertDir.ts
@@ -1,7 +1,30 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { getOpenSslTrustDir } from "@devcontainer-dev-certs/shared";
+import { getOpenSslTrustDir, log } from "@devcontainer-dev-certs/shared";
+
+// Absolute paths only, no shell metacharacters. The value is sourced from
+// workspace configuration (`devcontainer-dev-certs.sslCertDirs`) which a
+// malicious workspace can set — we get written into shell profile files
+// that run at every login, so we reject anything that isn't a plain
+// colon-separated list of POSIX paths.
+const SAFE_PATH_CHAR = "[A-Za-z0-9._/+@%-]";
+const SAFE_COLON_PATHS_RE = new RegExp(
+  `^/${SAFE_PATH_CHAR}+(?::/${SAFE_PATH_CHAR}+)*$`
+);
+
+function isSafeColonPaths(value: string): boolean {
+  return SAFE_COLON_PATHS_RE.test(value);
+}
+
+// Belt-and-braces: even though we've validated the input, we still emit the
+// shell line with single quotes so a future regression in the validator
+// can't smuggle through command substitution. POSIX shells don't expand
+// anything inside single quotes — a literal `'` is encoded by closing the
+// quoted string, emitting an escaped quote, and reopening.
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
 
 /**
  * Ensure SSL_CERT_DIR includes the dev-certs trust directory alongside
@@ -22,7 +45,22 @@ export function ensureSslCertDir(systemCertDirs: string): void {
     return;
   }
 
+  if (!isSafeColonPaths(systemCertDirs)) {
+    log(
+      `Refusing to configure SSL_CERT_DIR: sslCertDirs value contains unexpected characters. ` +
+        `Expected colon-separated absolute paths only.`
+    );
+    return;
+  }
+  if (!isSafeColonPaths(trustDir)) {
+    log(
+      `Refusing to configure SSL_CERT_DIR: computed trust dir contains unexpected characters.`
+    );
+    return;
+  }
+
   const desiredValue = `${trustDir}:${systemCertDirs}`;
+  const quoted = shellSingleQuote(desiredValue);
 
   // Set for the current process and any child processes we spawn
   process.env["SSL_CERT_DIR"] = desiredValue;
@@ -35,7 +73,7 @@ export function ensureSslCertDir(systemCertDirs: string): void {
     if (fs.existsSync(profileDir) && !fs.existsSync(profileScript)) {
       fs.writeFileSync(
         profileScript,
-        `export SSL_CERT_DIR="${desiredValue}"\n`,
+        `export SSL_CERT_DIR=${quoted}\n`,
         { mode: 0o644 }
       );
     }
@@ -54,7 +92,7 @@ export function ensureSslCertDir(systemCertDirs: string): void {
       if (!content.includes(marker)) {
         fs.appendFileSync(
           bashrc,
-          `\n${marker}\nexport SSL_CERT_DIR="${desiredValue}"\n`
+          `\n${marker}\nexport SSL_CERT_DIR=${quoted}\n`
         );
       }
     }


### PR DESCRIPTION
## Summary
This PR hardens security across the dev-certs infrastructure by addressing three categories of vulnerabilities: insecure file permissions on private key material, predictable temporary file names, and insufficient input validation on configuration values.

## Key Changes

**File Permissions & Private Key Protection**
- Set explicit `0o600` (read/write owner only) permissions on all files containing private key material (PFX files, unencrypted key PEMs)
- Set `0o644` (world-readable) permissions on public certificate files
- Use `fs.mkdtempSync()` instead of manual directory creation to ensure temp directories are created with secure `0o700` permissions
- Updated `exportPfx()`, `exportPem()`, and `exportLoadedCert()` to apply appropriate file modes on all writes

**Predictable Temporary File Names**
- Replace `Date.now()`-based temp file naming with `randomUUID()` for unpredictable filenames
- Affected files: `macStore.ts`, `windowsStore.ts` (trust/verify operations)
- Prevents symlink race attacks on shared `/tmp` directories in multi-user environments

**Input Validation & Shell Injection Prevention**
- Add regex validation for `sslCertDirs` configuration to ensure only colon-separated absolute POSIX paths (no shell metacharacters)
- Implement `shellSingleQuote()` function to safely quote paths in shell exports, preventing command substitution
- Add newline validation in shell feature script to prevent PAM environment injection attacks
- Validate all feature options against embedded newlines before writing to `/etc/environment`
- Add `append_env()` function with newline rejection for safe environment variable writing

**Certificate Rotation & Cleanup**
- Sweep stale `aspnetcore-localhost-*.pem` files from previous cert rotations before installing new certs
- Prevents OpenSSL clients from trusting expired/revoked certificates alongside new ones
- Applies to both Linux and workspace extension cert installation paths

**Symlink Race Condition Fixes**
- Add `EEXIST` exception handling in hash symlink creation to handle concurrent rehash operations atomically
- Refactor symlink creation into shared `createHashSymlinkForHash()` function
- Applies to both `rehash.ts` and `linuxStore.ts`

**macOS Certificate Removal Improvements**
- Replace broad `-c localhost` matching with SHA-1 thumbprint-based deletion (`-Z` flag)
- Only delete keychain entries for certs we actually have on disk, preventing accidental removal of unrelated localhost certificates
- Increase loop bound from 10 to 100 iterations to handle duplicate entries from past regenerations

**OpenSSL Dependency Hardening**
- Move `ensure_openssl()` check to the beginning of `setup-cert.sh` to fail fast rather than silently warn
- Prevents partial certificate installation with misleading success exit codes

## Notable Implementation Details
- All private key material now uses consistent `0o600` permissions across platforms
- Temporary directories created with `mkdtempSync()` are automatically `0o700`, providing defense-in-depth
- Shell quoting uses POSIX single-quote escaping (`'...'` with `'\''` for embedded quotes) to prevent any shell expansion
- Certificate rotation cleanup is idempotent and handles concurrent operations gracefully
- Input validation happens early in the feature script before any file operations

https://claude.ai/code/session_0175eoFR3mkCKnLQ8Ct495h5