### PR TITLE
Fix /tmp permission loss under buildah/podman (#47) and bump to 1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ Open the repo in VS Code and press F5. The `build-extensions` task will:
 
 The Extension Development Host opens with the UI extension loaded on the host side. To test the full devcontainer flow, reopen `.out/test-project/` in a container.
 
+## Known issues
+
+### podman: subsequent feature's `apt-get update` fails with `Couldn't create temporary file /tmp/apt.conf.XXX`
+
+This is [containers/buildah#6747](https://github.com/containers/buildah/issues/6747): when a devcontainer feature is installed via the `RUN --mount=type=bind,target=/tmp/build-features-src/<feat>_0 ...` pattern the devcontainer CLI generates, buildah/podman can commit the resulting layer with `/tmp` reset from `1777 root:root` to `0755 root:root`. A later feature that calls `apt-get update` then fails because `_apt` (uid 42) can no longer write to `/tmp`. Docker is not affected.
+
+This feature applies the workaround at the end of its own install script, so combinations like `devcontainer-dev-certs` + `azure-functions-core-tools` on podman work out of the box. If you hit the same class of failure with a *different* feature, copy the standalone [`examples/buildah-tmp-fix/`](examples/buildah-tmp-fix/) local feature into your `.devcontainer/` and place it in `devcontainer.json` between the offending feature and the consumer.
+
 ## Limitations
 
 - **Auto-generated dev cert matches .NET's format only.** The `generateDotNetCert` flow produces a cert identical to `dotnet dev-certs https` (specific OID marker, subject, SAN entries). To sync differently-shaped certs (corporate CAs, custom wildcard certs, etc.), add them via the `devcontainerDevCerts.userCertificates` VS Code setting — they're copied as-is.

--- a/examples/buildah-tmp-fix/README.md
+++ b/examples/buildah-tmp-fix/README.md
@@ -1,0 +1,53 @@
+# buildah-tmp-fix
+
+Workaround feature for [containers/buildah#6747](https://github.com/containers/buildah/issues/6747).
+
+## When you need this
+
+You're using podman (or any buildah-based build pipeline) and a devcontainer feature install fails partway through with:
+
+```
+Err:N <some-repo> InRelease
+  Couldn't create temporary file /tmp/apt.conf.XXX for passing config to apt-key
+```
+
+The cause is a buildah bug that resets the mode and ownership of every parent directory of a `RUN --mount=type=bind,target=...` mount target on layer commit. The devcontainer CLI generates exactly this RUN pattern with `target=/tmp/build-features-src/<feature>_0` for every feature, so `/tmp` ends up at `0755 root:root` after the offending feature commits. The next feature that runs `apt-get update` fails because `_apt` (uid 42) can no longer write to `/tmp`.
+
+Docker is not affected. The bug is buildah/podman-specific.
+
+## How to use it
+
+1. Copy this directory into your repo, for example next to your `.devcontainer/`:
+
+   ```
+   .devcontainer/
+       devcontainer.json
+       local-features/
+           buildah-tmp-fix/
+               devcontainer-feature.json
+               install.sh
+   ```
+
+2. Reference it from `devcontainer.json`, placed **between** the feature whose install triggers the bug and the next feature that runs `apt-get update`:
+
+   ```json
+   {
+       "features": {
+           "ghcr.io/some/offending-feature:1": {},
+           "./local-features/buildah-tmp-fix": {},
+           "ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {}
+       }
+   }
+   ```
+
+   Declaration order matters: with no explicit `installsAfter` constraints, the devcontainer CLI orders features by the order they appear in `devcontainer.json`. If any of your features declare `installsAfter` that pull them out of declaration order, add a matching `installsAfter` to `buildah-tmp-fix`'s `devcontainer-feature.json` to pin it.
+
+3. Rebuild the container.
+
+## How it works
+
+A bare `chmod 1777 /tmp` doesn't survive the layer commit when `/tmp` is already `1777` in the lower overlay layer — the chmod is a syscall-level no-op and the overlay never copies `/tmp` up with a corrected entry. The fix forces a content-level change by creating and removing a marker file, which forces overlayfs to copy `/tmp` up into the upper layer; the subsequent `chmod` then lands on the upper-layer copy and is captured by the layer commit.
+
+## Limitations
+
+The upstream issue notes that this class of workaround can be non-deterministic in deeper directory hierarchies. For `/tmp` specifically the workaround has been reliable in testing, but if you see a flaky build, rebuilding usually clears it. Track [containers/buildah#6747](https://github.com/containers/buildah/issues/6747) for the upstream fix.

--- a/examples/buildah-tmp-fix/devcontainer-feature.json
+++ b/examples/buildah-tmp-fix/devcontainer-feature.json
@@ -1,0 +1,6 @@
+{
+  "id": "buildah-tmp-fix",
+  "version": "0.1.0",
+  "name": "Buildah /tmp permission fix",
+  "description": "Workaround for containers/buildah#6747. When a previous devcontainer feature's install RUN uses `--mount=type=bind,target=/tmp/...`, buildah/podman commits the layer with /tmp at mode 0755 root:root instead of 1777. A later feature that runs apt-get update then fails with 'Couldn't create temporary file /tmp/apt.conf.XXX'. Place this feature in devcontainer.json BETWEEN the offending upstream feature and any subsequent feature that runs apt-get update."
+}

--- a/examples/buildah-tmp-fix/install.sh
+++ b/examples/buildah-tmp-fix/install.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Workaround for containers/buildah#6747:
+#   https://github.com/containers/buildah/issues/6747
+#
+# When a devcontainer feature is installed via
+#   RUN --mount=type=bind,from=<stage>,target=/tmp/build-features-src/<feat>_0 ...
+# buildah/podman can commit the resulting layer with /tmp reset to mode 0755
+# root:root instead of its original 1777. A subsequent feature that runs
+# apt-get update then fails because _apt (uid 42) can no longer write to /tmp:
+#
+#   Couldn't create temporary file /tmp/apt.conf.XXX for passing config to apt-key
+#
+# Place this feature in devcontainer.json between the offending upstream
+# feature and the consumer of apt-get update. A bare `chmod 1777 /tmp` is a
+# no-op when /tmp is already 1777 in the lower overlay layer, so we first
+# force overlayfs to copy /tmp into the upper layer by creating and removing
+# a marker file, then re-assert the mode. No-op on Docker.
+
+set -e
+
+if marker="$(mktemp /tmp/.buildah-tmp-fix.XXXXXX 2>/dev/null)"; then
+    rm -f -- "${marker}"
+fi
+chmod 1777 /tmp 2>/dev/null || true

--- a/package-lock.json
+++ b/package-lock.json
@@ -7075,7 +7075,7 @@
     },
     "src/shared": {
       "name": "@devcontainer-dev-certs/shared",
-      "version": "1.0.4-pre",
+      "version": "1.0.4",
       "devDependencies": {
         "@types/vscode": "^1.100.0",
         "typescript": "^6.0.3"
@@ -7083,7 +7083,7 @@
     },
     "src/vscode-ui-extension": {
       "name": "devcontainer-dev-certs-host",
-      "version": "1.0.4-pre",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@devcontainer-dev-certs/shared": "*",
@@ -7106,7 +7106,7 @@
     },
     "src/vscode-workspace-extension": {
       "name": "devcontainer-dev-certs-remote",
-      "version": "1.0.4-pre",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@devcontainer-dev-certs/shared": "*"

--- a/src/devcontainer-feature/src/devcontainer-dev-certs/devcontainer-feature.json
+++ b/src/devcontainer-feature/src/devcontainer-dev-certs/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "devcontainer-dev-certs",
-  "version": "1.0.4-pre",
+  "version": "1.0.4",
   "name": "Dev Container Development Certificates",
   "description": "Enables trusted HTTPS in Dev Containers by preparing certificate trust infrastructure and installing companion VS Code extensions that automatically generate, trust, and transfer ASP.NET and Aspire compatible development certificates from the host machine. Add to your devcontainer.json: \"features\": { \"ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs:1\": {} }",
   "documentationURL": "https://github.com/dnegstad/devcontainer-dev-certs",

--- a/src/devcontainer-feature/src/devcontainer-dev-certs/install.sh
+++ b/src/devcontainer-feature/src/devcontainer-dev-certs/install.sh
@@ -158,6 +158,29 @@ if id "${REMOTE_USER}" &>/dev/null; then
     done
 fi
 
+# Workaround for containers/buildah#6747: a `RUN --mount=type=bind,target=X`
+# committed by buildah/podman can reset the mode and ownership of every
+# parent directory of the mount target. The devcontainer CLI generates such a
+# RUN for every feature with target `/tmp/build-features-src/<feature>_0`,
+# which leaves `/tmp` at mode 0755 root:root instead of 1777 in the committed
+# layer — even when nothing in the RUN touched `/tmp` itself.
+#
+# The next feature that runs `apt-get update` then fails with:
+#   Couldn't create temporary file /tmp/apt.conf.XXX for passing config to apt-key
+# because `_apt` (uid 42) can no longer write to `/tmp`. azure-functions-core-tools
+# is the canonical trigger; see issue #47.
+#
+# A bare `chmod 1777 /tmp` doesn't survive the layer commit: when the mode is
+# already 1777 in the lower overlay layer the chmod is a no-op and buildah
+# never serializes a corrected `/tmp` entry into the diff. The reliable
+# workaround is to force overlayfs to copy `/tmp` up to the upper layer by
+# creating and removing a marker file, then re-asserting the mode. No-op on
+# Docker, where the commit preserves `/tmp` correctly.
+if __tmpfix_marker="$(mktemp /tmp/.devcontainer-dev-certs-tmpfix.XXXXXX 2>/dev/null)"; then
+    rm -f -- "${__tmpfix_marker}"
+    chmod 1777 /tmp 2>/dev/null || true
+fi
+
 echo "Dev certificate infrastructure ready."
 echo "  .NET cert store:      ${DOTNET_STORE_DIR}"
 echo "  .NET root store:      ${DOTNET_ROOT_STORE_DIR}"

--- a/src/shared/package.json
+++ b/src/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devcontainer-dev-certs/shared",
-  "version": "1.0.4-pre",
+  "version": "1.0.4",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/src/vscode-ui-extension/package.json
+++ b/src/vscode-ui-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Dev Container Dev Certificates (Host)",
   "description": "Generates and trusts ASP.NET and Aspire compatible HTTPS development certificates on the host machine for use in Dev Containers and remote environments.",
   "icon": "images/dn_ui_extension_icon_256.png",
-  "version": "1.0.4-pre",
+  "version": "1.0.4",
   "publisher": "dnegstad",
   "license": "MIT",
   "repository": {

--- a/src/vscode-workspace-extension/package.json
+++ b/src/vscode-workspace-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Dev Container Dev Certificates (Remote)",
   "description": "Receives and installs ASP.NET and Aspire compatible HTTPS development certificates inside Dev Containers and remote environments.",
   "icon": "images/dn_workspace_extension_icon_256.png",
-  "version": "1.0.4-pre",
+  "version": "1.0.4",
   "publisher": "dnegstad",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- Fixes #47. When this feature was combined with another feature that runs `apt-get update` (e.g. `jlaundry/azure-functions-core-tools`) on podman, the second feature failed with `Couldn't create temporary file /tmp/apt.conf.XXX for passing config to apt-key`. Root cause is upstream [containers/buildah#6747](https://github.com/containers/buildah/issues/6747): a `RUN --mount=type=bind,target=/tmp/...` commits a layer where `/tmp` has been reset from `1777 root:root` to `0755 root:root`. `apt`-using features re-establish `/tmp` mode as a dpkg postinst side effect; this feature did nothing apt-related by default, so the broken mode persisted in the committed layer and `_apt` (uid 42) couldn't `mkstemp` in `/tmp` on the next feature's `apt-get update`.
- Workaround at end of `install.sh`: `mktemp /tmp/.devcontainer-dev-certs-tmpfix.XXXXXX && rm + chmod 1777 /tmp`. A bare `chmod 1777 /tmp` doesn't survive the commit because the syscall is a no-op when the lower-layer mode is already `1777`; the marker file forces overlayfs to copy `/tmp` up into the upper layer so the chmod lands somewhere the layer-commit serializer captures. No-op on Docker.
- Adds [`examples/buildah-tmp-fix/`](examples/buildah-tmp-fix/) — a standalone local feature applying the same workaround, for users who hit buildah#6747 with a different combination of features.
- Documents the bug, the fix, and the standalone workaround in `README.md` under a new **Known issues** section.
- Bumps version to `1.0.4` across `devcontainer-feature.json`, the three `package.json` files, and the lockfile.

## Test plan

- [x] Reproduced the failure under podman 5.8.2 (rootful, overlay, crun) with the both-features `devcontainer up`
- [x] Confirmed each feature passes in isolation under podman
- [x] Bisected the corruption to the `RUN --mount=type=bind` layer commit (empty install.sh still triggers it); confirmed `/tmp` mode is fine throughout the RUN and only resets in the committed layer
- [x] Verified the fix end-to-end with a minimal Containerfile that replays the exact devcontainer CLI RUN pattern: post-RUN `/tmp = 1777`, `_apt mktemp` ✓, `apt-get update` ✓
- [x] Verified the standalone `examples/buildah-tmp-fix/` feature restores `/tmp` mode when placed between a "buggy" feature and a downstream `apt-get update`
- [ ] Re-run via devcontainer CLI with the published feature after this PR merges and the release publishes 1.0.4 to confirm the user's original `devcontainer.json` succeeds end-to-end on podman

🤖 Generated with [Claude Code](https://claude.com/claude-code)