### PR TITLE
Add V3 cert wire protocol with password preservation and store opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ User-managed certs are **never** added to the host OS trust store; the assumptio
 
 ### Password handling
 
-The user's PFX password is preserved end-to-end. For `pfxPath` sources, the original file bytes are sent to the container verbatim — no decrypt-then-reencrypt round trip strips the password on the wire or on disk. For `pemCertPath` sources, the `pfxPassword` field doubles as the encryption password used to synthesize a `.pfx` for extra destinations: if `pfxPassword` is unset on a PEM-sourced entry, no `.pfx` is produced. Set `pfxPassword: ""` (the empty string) to explicitly opt into a passwordless `.pfx`.
+The user's PFX password is preserved end-to-end. For `pfxPath` sources, the original file bytes are sent to the container verbatim — no decrypt-then-reencrypt round trip strips the password on the wire or on disk. For `pemCertPath` sources, the `pfxPassword` field doubles as the encryption password used to synthesize a `.pfx` for extra destinations; if unset, the synthesized `.pfx` is passwordless (matching the source PEM key file's on-disk posture — neither carries a password, so there's nothing to strip).
 
 ### .NET X509Store install (opt-in)
 
@@ -204,10 +204,10 @@ The auto-generated dotnet-dev cert is always installed to the store regardless o
 | `pem` | `{name}.pem` (cert only) |
 | `key` | `{name}.key` (private key; skipped when no key is available) |
 | `pem-bundle` | `{name}-bundle.pem` (cert + key concatenated) |
-| `pfx` | `{name}.pfx` (skipped when no PFX is available — see below) |
+| `pfx` | `{name}.pfx` (skipped when no private key is available) |
 | `all` *(default)* | all of the above |
 
-For PFX-sourced user certs the destination `.pfx` is the original file bytes verbatim — openable with the same `pfxPassword` you configured. For PEM-sourced user certs the `.pfx` is synthesized only when `pfxPassword` is set on the entry (use `""` for an explicit empty password); without it the `.pfx` is skipped and a warning is logged. CA-only entries (no private key) never produce a `.pfx`.
+For PFX-sourced user certs the destination `.pfx` is the original file bytes verbatim — openable with the same `pfxPassword` you configured. For PEM-sourced user certs the `.pfx` is synthesized from the PEM key material; `pfxPassword` (if set) becomes its encryption password, otherwise it's passwordless.
 
 After every cert has been written, OpenSSL's `c_rehash` runs once per unique destination directory (not once per cert and not once per write), so adding more synced certs doesn't multiply the rehash cost.
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,28 @@ Each entry supplies exactly one of `pfxPath` (+ optional `pfxPassword`) or `pemC
 
 User-managed certs are **never** added to the host OS trust store; the assumption is you already trust them on the host if you're syncing them.
 
+### Password handling
+
+The user's PFX password is preserved end-to-end. For `pfxPath` sources, the original file bytes are sent to the container verbatim — no decrypt-then-reencrypt round trip strips the password on the wire or on disk. For `pemCertPath` sources, the `pfxPassword` field doubles as the encryption password used to synthesize a `.pfx` for extra destinations: if `pfxPassword` is unset on a PEM-sourced entry, no `.pfx` is produced. Set `pfxPassword: ""` (the empty string) to explicitly opt into a passwordless `.pfx`.
+
+### .NET X509Store install (opt-in)
+
+By default, user-managed certs are **not** copied into the container's .NET X509Store (`~/.dotnet/corefx/cryptography/x509stores/my/`). `StoreName.My` enumeration on Linux constructs `X509Certificate2(path, /* password */ null)` and has no per-file password channel, so the on-disk file there has to be passwordless — copying your passworded PFX into that location would silently strip its password and leave the private key plain-text-equivalent on disk.
+
+If you specifically need `X509Store(StoreName.My, StoreLocation.CurrentUser)` enumeration to find your user certs (for example, because some code reads `StoreName.My` directly), set:
+
+```json
+{
+    "devcontainerDevCerts.installUserCertsToDotNetStore": true
+}
+```
+
+Setting this acknowledges that the in-container PFX copy is passwordless. The original source file on the host is untouched, and the password-preserving copies still flow to extra destinations.
+
+To exempt an individual entry from the global setting (e.g., keep most of your user certs in the store but carve out one sensitive cert), add `"excludeFromDotNetStore": true` to that `userCertificates` entry. Has no effect when the global setting is `false` (no user certs go to the store anyway).
+
+The auto-generated dotnet-dev cert is always installed to the store regardless of these settings — it's intrinsically passwordless and the store IS its canonical location.
+
 ## Extra destinations
 
 `extraCertDestinations` writes cert artifacts into additional directories inside the container — useful for non-.NET workloads (nginx, Java keystores, Python requests bundles, etc.). Each entry is a directory; every synced cert gets a set of files under it named after the cert. Formats:
@@ -182,8 +204,10 @@ User-managed certs are **never** added to the host OS trust store; the assumptio
 | `pem` | `{name}.pem` (cert only) |
 | `key` | `{name}.key` (private key; skipped when no key is available) |
 | `pem-bundle` | `{name}-bundle.pem` (cert + key concatenated) |
-| `pfx` | `{name}.pfx` (skipped when no key is available) |
+| `pfx` | `{name}.pfx` (skipped when no PFX is available — see below) |
 | `all` *(default)* | all of the above |
+
+For PFX-sourced user certs the destination `.pfx` is the original file bytes verbatim — openable with the same `pfxPassword` you configured. For PEM-sourced user certs the `.pfx` is synthesized only when `pfxPassword` is set on the entry (use `""` for an explicit empty password); without it the `.pfx` is skipped and a warning is logged. CA-only entries (no private key) never produce a `.pfx`.
 
 After every cert has been written, OpenSSL's `c_rehash` runs once per unique destination directory (not once per cert and not once per write), so adding more synced certs doesn't multiply the rehash cost.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7075,7 +7075,7 @@
     },
     "src/shared": {
       "name": "@devcontainer-dev-certs/shared",
-      "version": "1.1.0-pre",
+      "version": "1.1.0",
       "devDependencies": {
         "@types/vscode": "^1.100.0",
         "typescript": "^6.0.3"
@@ -7083,7 +7083,7 @@
     },
     "src/vscode-ui-extension": {
       "name": "devcontainer-dev-certs-host",
-      "version": "1.1.0-pre",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@devcontainer-dev-certs/shared": "*",
@@ -7106,7 +7106,7 @@
     },
     "src/vscode-workspace-extension": {
       "name": "devcontainer-dev-certs-remote",
-      "version": "1.1.0-pre",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@devcontainer-dev-certs/shared": "*"

--- a/src/devcontainer-feature/src/devcontainer-dev-certs/devcontainer-feature.json
+++ b/src/devcontainer-feature/src/devcontainer-dev-certs/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "devcontainer-dev-certs",
-  "version": "1.1.0-pre",
+  "version": "1.1.0",
   "name": "Dev Container Development Certificates",
   "description": "Enables trusted HTTPS in Dev Containers by preparing certificate trust infrastructure and installing companion VS Code extensions that automatically generate, trust, and transfer ASP.NET and Aspire compatible development certificates from the host machine. Add to your devcontainer.json: \"features\": { \"ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs:1\": {} }",
   "documentationURL": "https://github.com/dnegstad/devcontainer-dev-certs",

--- a/src/shared/package.json
+++ b/src/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devcontainer-dev-certs/shared",
-  "version": "1.1.0-pre",
+  "version": "1.1.0",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/src/shared/src/index.ts
+++ b/src/shared/src/index.ts
@@ -4,6 +4,8 @@ export type {
   CertKind,
   CertMaterialV2,
   CertBundle,
+  CertMaterialV3,
+  CertBundleV3,
   DestFormat,
 } from "./types";
 export { DOTNET_DEV_CERT_NAME } from "./types";

--- a/src/shared/src/types.ts
+++ b/src/shared/src/types.ts
@@ -39,13 +39,11 @@ export interface CertMaterialV2 {
    */
   thumbprint: string;
   /**
-   * PFX bytes with the user's password preserved. For PFX-sourced user
-   * entries these are the original file bytes verbatim. For PEM-sourced
-   * entries this is a freshly-built PFX encrypted with `pfxPassword` from
-   * the user's settings, or omitted if no password was provided. For the
-   * auto-generated dotnet-dev cert these are intrinsically passwordless
-   * (no password to preserve). Consumers that don't have the password
-   * cannot open these — that's the point.
+   * Passwordless PFX bytes. The V2 IPC contract assumes any cert that
+   * carries a PFX is openable with the empty password — the .NET X509Store
+   * on Linux can't accept per-file passwords, and V2 consumers wrote these
+   * bytes directly to it. Omitted when no private key is available
+   * (CA-only user certs).
    */
   pfxBase64?: string;
   pemCertBase64: string;
@@ -54,26 +52,58 @@ export interface CertMaterialV2 {
   /** Public-cert-only PFX for the .NET Root store. Only present when trustInContainer = true. */
   rootPfxBase64?: string;
   trustInContainer: boolean;
-  /**
-   * True when the cert should be installed into ~/.dotnet/corefx/cryptography/
-   * x509stores/my/ — the .NET CurrentUser\My store on Linux. Always true for
-   * the dotnet-dev cert (canonical location). For user certs this reflects
-   * the resolved opt-in: global `installUserCertsToDotNetStore` AND not the
-   * per-cert `excludeFromDotNetStore`. The workspace extension MUST NOT write
-   * to the store when this is false, and MUST sweep any prior store copy.
-   */
-  installToDotNetStore: boolean;
-  /**
-   * Passwordless PFX bytes — populated ONLY when `installToDotNetStore` is
-   * true. For the dotnet-dev cert this is the same payload as `pfxBase64`
-   * (no password either way). For user certs this is a separate passwordless
-   * re-encode of the same cert+key, kept distinct from `pfxBase64` so we
-   * don't strip the user's password from artifacts written elsewhere. NEVER
-   * write these bytes to any location other than the X509Store directory.
-   */
-  dotNetStorePfxBase64?: string;
 }
 
 export interface CertBundle {
   certs: CertMaterialV2[];
+}
+
+/**
+ * V3 certificate material. Adds a deliberate split between the
+ * password-preserving payload for "elsewhere" destinations and the
+ * passwordless payload for the .NET X509Store, gated by an explicit
+ * per-cert install flag. V3 consumers (new workspace extension) read
+ * these fields directly; older workspaces continue speaking V2 via the
+ * downmap on the host side.
+ */
+export interface CertMaterialV3 {
+  kind: CertKind;
+  name: string;
+  thumbprint: string;
+  /**
+   * PFX bytes with the user's password preserved. For PFX-sourced user
+   * entries these are the original file bytes verbatim. For PEM-sourced
+   * entries this is a freshly-built PFX encrypted with `pfxPassword` from
+   * the user's settings, or with an empty password if `pfxPassword` was
+   * unset (matching the source PEM key file's on-disk posture). For the
+   * auto-generated dotnet-dev cert these are intrinsically passwordless.
+   * V3 consumers must NOT write these bytes to the .NET X509Store — they
+   * may carry a password the store-enumeration code can't supply.
+   */
+  pfxBase64?: string;
+  pemCertBase64: string;
+  pemKeyBase64?: string;
+  rootPfxBase64?: string;
+  trustInContainer: boolean;
+  /**
+   * True when the cert should be installed into ~/.dotnet/corefx/cryptography/
+   * x509stores/my/. Always true for the dotnet-dev cert. For user certs this
+   * reflects the resolved opt-in: global `installUserCertsToDotNetStore` AND
+   * not the per-cert `excludeFromDotNetStore`. The workspace extension MUST
+   * NOT write to the store when this is false, and MUST sweep any prior
+   * store copy keyed by this cert's thumbprint.
+   */
+  installToDotNetStore: boolean;
+  /**
+   * Passwordless PFX bytes — populated ONLY when `installToDotNetStore` is
+   * true. The deliberate side-effect of opting into the store: the bytes
+   * here have the user's password stripped so .NET's null-password
+   * enumeration can open them. NEVER write these bytes anywhere other than
+   * the X509Store directory.
+   */
+  dotNetStorePfxBase64?: string;
+}
+
+export interface CertBundleV3 {
+  certs: CertMaterialV3[];
 }

--- a/src/shared/src/types.ts
+++ b/src/shared/src/types.ts
@@ -38,7 +38,15 @@ export interface CertMaterialV2 {
    * defines "thumbprint" as SHA-1 so the wire-protocol field has to match.
    */
   thumbprint: string;
-  /** Omitted when no private key is available (CA-only user certs). */
+  /**
+   * PFX bytes with the user's password preserved. For PFX-sourced user
+   * entries these are the original file bytes verbatim. For PEM-sourced
+   * entries this is a freshly-built PFX encrypted with `pfxPassword` from
+   * the user's settings, or omitted if no password was provided. For the
+   * auto-generated dotnet-dev cert these are intrinsically passwordless
+   * (no password to preserve). Consumers that don't have the password
+   * cannot open these — that's the point.
+   */
   pfxBase64?: string;
   pemCertBase64: string;
   /** Omitted for CA-only user certs. */
@@ -46,6 +54,24 @@ export interface CertMaterialV2 {
   /** Public-cert-only PFX for the .NET Root store. Only present when trustInContainer = true. */
   rootPfxBase64?: string;
   trustInContainer: boolean;
+  /**
+   * True when the cert should be installed into ~/.dotnet/corefx/cryptography/
+   * x509stores/my/ — the .NET CurrentUser\My store on Linux. Always true for
+   * the dotnet-dev cert (canonical location). For user certs this reflects
+   * the resolved opt-in: global `installUserCertsToDotNetStore` AND not the
+   * per-cert `excludeFromDotNetStore`. The workspace extension MUST NOT write
+   * to the store when this is false, and MUST sweep any prior store copy.
+   */
+  installToDotNetStore: boolean;
+  /**
+   * Passwordless PFX bytes — populated ONLY when `installToDotNetStore` is
+   * true. For the dotnet-dev cert this is the same payload as `pfxBase64`
+   * (no password either way). For user certs this is a separate passwordless
+   * re-encode of the same cert+key, kept distinct from `pfxBase64` so we
+   * don't strip the user's password from artifacts written elsewhere. NEVER
+   * write these bytes to any location other than the X509Store directory.
+   */
+  dotNetStorePfxBase64?: string;
 }
 
 export interface CertBundle {

--- a/src/vscode-ui-extension/package.json
+++ b/src/vscode-ui-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Dev Container Dev Certificates (Host)",
   "description": "Generates and trusts ASP.NET and Aspire compatible HTTPS development certificates on the host machine for use in Dev Containers and remote environments.",
   "icon": "images/dn_ui_extension_icon_256.png",
-  "version": "1.1.0-pre",
+  "version": "1.1.0",
   "publisher": "dnegstad",
   "license": "MIT",
   "repository": {

--- a/src/vscode-ui-extension/package.json
+++ b/src/vscode-ui-extension/package.json
@@ -78,7 +78,7 @@
               },
               "pfxPassword": {
                 "type": "string",
-                "description": "Password for the PFX, if any. Leave unset for an empty password."
+                "description": "Password for the certificate's PFX form. For pfxPath sources, the password used to open the file. For pemCertPath sources, the password used to encrypt the synthesized .pfx written to extra destinations — if unset, no .pfx is produced and only PEM artifacts reach destinations. Set to an empty string (\"\") to explicitly opt into a passwordless .pfx."
               },
               "pemCertPath": {
                 "type": "string",
@@ -92,9 +92,19 @@
                 "type": "boolean",
                 "default": true,
                 "description": "When true (default), plant the cert in the OpenSSL trust directory and the .NET Root store inside the container."
+              },
+              "excludeFromDotNetStore": {
+                "type": "boolean",
+                "default": false,
+                "description": "When true, exempts this certificate from devcontainerDevCerts.installUserCertsToDotNetStore. Use to keep a sensitive cert out of the .NET X509Store while still installing other user certs there. Has no effect when the top-level setting is false (no user certs go to the store anyway)."
               }
             }
           }
+        },
+        "devcontainerDevCerts.installUserCertsToDotNetStore": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, copies every user certificate from devcontainerDevCerts.userCertificates into the container's .NET X509Store (~/.dotnet/corefx/cryptography/x509stores/my/) so X509Store(StoreName.My, StoreLocation.CurrentUser) enumerates them. SECURITY WARNING: .NET's StoreName.My enumeration on Linux opens each file with a null password and cannot accept per-file passwords, so each cert's copy stored there has its password stripped. The private key sits on disk in plain-text-equivalent form, protected only by file permissions (0o600). Leave this false (the default) unless you specifically need .NET store enumeration to find your user certs. The auto-generated dotnet-dev cert is always installed to the store regardless of this setting (it has no password to strip, and the store IS its canonical location). To exempt an individual cert from this global setting, add excludeFromDotNetStore: true to that entry."
         }
       }
     }

--- a/src/vscode-ui-extension/package.json
+++ b/src/vscode-ui-extension/package.json
@@ -78,7 +78,7 @@
               },
               "pfxPassword": {
                 "type": "string",
-                "description": "Password for the certificate's PFX form. For pfxPath sources, the password used to open the file. For pemCertPath sources, the password used to encrypt the synthesized .pfx written to extra destinations — if unset, no .pfx is produced and only PEM artifacts reach destinations. Set to an empty string (\"\") to explicitly opt into a passwordless .pfx."
+                "description": "Password for the certificate's PFX form. For pfxPath sources, the password used to open the file (preserved end-to-end — the .pfx written to extra destinations opens with this same password). For pemCertPath sources, the encryption password applied to the .pfx synthesized for extra destinations; if unset, the synthesized .pfx is passwordless (matching the source PEM key file's on-disk posture)."
               },
               "pemCertPath": {
                 "type": "string",

--- a/src/vscode-ui-extension/src/cert/exporter.ts
+++ b/src/vscode-ui-extension/src/cert/exporter.ts
@@ -92,15 +92,19 @@ export async function exportRootPfx(
 export interface ExportedLoadedCert {
   pemCertPath: string;
   pemKeyPath: string | null;
-  pfxPath: string | null;
   rootPfxPath: string | null;
 }
 
 /**
- * Export a user-managed (or generically loaded) certificate to a directory
- * under a stable `{name}.*` filename scheme. PFX artifacts are only produced
- * when the cert has a private key attached; the root PFX is only produced
- * when `includeRootPfx` is true.
+ * Export a user-managed (or generically loaded) certificate's PEM artifacts
+ * to a directory under a stable `{name}.*` filename scheme. The cert is
+ * always written; the key is only written when a key is attached; the
+ * public-cert-only root PFX is only produced when `includeRootPfx` is true.
+ *
+ * Notably this does NOT synthesize a key-bearing `{name}.pfx`. That decision
+ * lives in certProvider, where the user's pfxPassword is in scope — silently
+ * encoding a passwordless PFX here would strip the user's password without
+ * their consent. See certProvider.ts:loadUserCert for the PFX byte source.
  */
 export async function exportLoadedCert(
   loaded: LoadedCert,
@@ -114,17 +118,9 @@ export async function exportLoadedCert(
   fs.writeFileSync(pemCertPath, loaded.cert.pem, { mode: PUBLIC_FILE_MODE });
 
   let pemKeyPath: string | null = null;
-  let pfxPath: string | null = null;
   if (loaded.key) {
     pemKeyPath = path.join(outputDir, `${name}.key`);
     fs.writeFileSync(pemKeyPath, loaded.key.pem, { mode: PRIVATE_FILE_MODE });
-
-    const pfxBytes = await buildPfx({
-      cert: loaded.cert,
-      key: loaded.key,
-    });
-    pfxPath = path.join(outputDir, `${name}.pfx`);
-    fs.writeFileSync(pfxPath, pfxBytes, { mode: PRIVATE_FILE_MODE });
   }
 
   let rootPfxPath: string | null = null;
@@ -134,5 +130,5 @@ export async function exportLoadedCert(
     fs.writeFileSync(rootPfxPath, rootBytes, { mode: PUBLIC_FILE_MODE });
   }
 
-  return { pemCertPath, pemKeyPath, pfxPath, rootPfxPath };
+  return { pemCertPath, pemKeyPath, rootPfxPath };
 }

--- a/src/vscode-ui-extension/src/certProvider.ts
+++ b/src/vscode-ui-extension/src/certProvider.ts
@@ -274,8 +274,7 @@ export class CertProvider {
       this.cachedUser.set(cacheKey, material);
       log(
         `User cert '${config.name}' ready. Thumbprint: ${material.thumbprint}; ` +
-          `installToDotNetStore=${installToDotNetStore}; ` +
-          `pfxBase64=${pfxBase64 ? "present" : "omitted"}`
+          `installToDotNetStore=${installToDotNetStore}`
       );
       return material;
     } finally {
@@ -286,11 +285,13 @@ export class CertProvider {
   /**
    * Build the password-preserving PFX bytes for a user cert. PFX-sourced
    * entries pass through their original file bytes verbatim — no decrypt /
-   * re-encrypt round-trip, so the user's password (including its absence)
-   * survives untouched. PEM-sourced entries are synthesized only when the
-   * user provided `pfxPassword`; without it we omit `pfxBase64` rather than
-   * silently producing a passwordless PFX. Empty string is treated as a
-   * deliberate "I want a passwordless PFX" signal and produces one.
+   * re-encrypt round-trip, so the user's password survives untouched (this
+   * is the consent contract: we never strip a password the user supplied).
+   * PEM-sourced entries get a fresh PFX built around their existing PEM
+   * material. If `pfxPassword` is set we use it as the encryption password;
+   * if it's unset we encode with an empty password, which matches the on-
+   * disk security posture of the source PEM key file (unencrypted either
+   * way — nothing to strip).
    */
   private async buildUserPfxBase64(
     loaded: LoadedCert,
@@ -300,18 +301,10 @@ export class CertProvider {
       return fs.readFileSync(config.pfxPath).toString("base64");
     }
     if (!loaded.key) return undefined;
-    if (config.pfxPassword === undefined) {
-      log(
-        `User cert '${config.name}': pemCertPath source with no pfxPassword; ` +
-          `omitting pfxBase64. Set pfxPassword (use "" for an explicit empty ` +
-          `password) to opt into PFX synthesis for extra destinations.`
-      );
-      return undefined;
-    }
     const bytes = await buildPfx({
       cert: loaded.cert,
       key: loaded.key,
-      password: config.pfxPassword,
+      password: config.pfxPassword ?? "",
     });
     return bytes.toString("base64");
   }

--- a/src/vscode-ui-extension/src/certProvider.ts
+++ b/src/vscode-ui-extension/src/certProvider.ts
@@ -10,8 +10,10 @@ import { buildPfx } from "./cert/pfx";
 import { assertValidCertName, log } from "@devcontainer-dev-certs/shared";
 import type {
   CertBundle,
+  CertBundleV3,
   CertMaterial,
   CertMaterialV2,
+  CertMaterialV3,
 } from "@devcontainer-dev-certs/shared";
 import { DOTNET_DEV_CERT_NAME } from "@devcontainer-dev-certs/shared";
 
@@ -30,9 +32,20 @@ export interface GetAllCertMaterialArgs {
   includeUserCerts: boolean;
 }
 
+/**
+ * Cached cert payload. Holds both wire shapes side-by-side so the V2 and
+ * V3 endpoints can both serve from the cache without recomputing — and so
+ * repeated V2 calls return object-identical entries (callers depend on
+ * cache hits skipping work, not on per-call snapshots).
+ */
+interface CachedCert {
+  v3: CertMaterialV3;
+  v2: CertMaterialV2;
+}
+
 export class CertProvider {
-  private cachedDotNet: CertMaterialV2 | null = null;
-  private cachedUser = new Map<string, CertMaterialV2>();
+  private cachedDotNet: CachedCert | null = null;
+  private cachedUser = new Map<string, CachedCert>();
   private warnedExpiredCerts = new Set<string>();
 
   constructor(private readonly certManager: CertManager) {}
@@ -60,26 +73,63 @@ export class CertProvider {
     if (!cert) return null;
 
     return {
-      thumbprint: cert.thumbprint,
-      pfxBase64: cert.pfxBase64 ?? "",
-      pemCertBase64: cert.pemCertBase64,
-      pemKeyBase64: cert.pemKeyBase64 ?? "",
-      rootPfxBase64: cert.rootPfxBase64 ?? "",
+      thumbprint: cert.v2.thumbprint,
+      pfxBase64: cert.v2.pfxBase64 ?? "",
+      pemCertBase64: cert.v2.pemCertBase64,
+      pemKeyBase64: cert.v2.pemKeyBase64 ?? "",
+      rootPfxBase64: cert.v2.rootPfxBase64 ?? "",
     };
   }
 
   /**
-   * Multi-cert entry point. Returns the bundle of certs requested by the
-   * caller, combining the optional auto-generated dotnet dev cert with any
-   * user-managed certificates configured in VS Code settings.
+   * V2 entry point — kept for backward compatibility with workspace
+   * extensions pinned to the V2 wire contract (passwordless `pfxBase64`,
+   * no `installToDotNetStore` flag). New code paths should call
+   * `getAllCertMaterialV3` instead.
+   *
+   * Downmap rules:
+   * - dotnet-dev: drop V3-only fields. `pfxBase64` is intrinsically
+   *   passwordless either way.
+   * - user certs: replace V3's password-preserving `pfxBase64` with the
+   *   cached passwordless variant. V2 consumers wrote `pfxBase64`
+   *   directly to the .NET X509Store, which requires passwordless; the
+   *   user's password is therefore stripped on the V2 wire as it was
+   *   before this change. Upgrading the workspace extension to V3
+   *   restores password preservation.
    */
   async getAllCertMaterial(
     args: GetAllCertMaterialArgs
   ): Promise<CertBundle> {
+    const certs = await this.collect(args);
+    return { certs: certs.map((c) => c.v2) };
+  }
+
+  /**
+   * V3 entry point. Returns the multi-cert bundle with the new password-
+   * preserving `pfxBase64`, the per-cert `installToDotNetStore` flag, and
+   * the (separate) passwordless `dotNetStorePfxBase64` payload when the
+   * cert opted into the store install.
+   */
+  async getAllCertMaterialV3(
+    args: GetAllCertMaterialArgs
+  ): Promise<CertBundleV3> {
+    const certs = await this.collect(args);
+    return { certs: certs.map((c) => c.v3) };
+  }
+
+  clearCache(): void {
+    this.cachedDotNet = null;
+    this.cachedUser.clear();
+    this.warnedExpiredCerts.clear();
+  }
+
+  private async collect(
+    args: GetAllCertMaterialArgs
+  ): Promise<CachedCert[]> {
     const config = vscode.workspace.getConfiguration("devcontainerDevCerts");
     const hostWantsDotNet = config.get<boolean>("generateDotNetCert", true);
 
-    const certs: CertMaterialV2[] = [];
+    const certs: CachedCert[] = [];
 
     if (args.includeDotNetDev && hostWantsDotNet) {
       const dotnet = await this.ensureDotNetDevCert(true);
@@ -101,8 +151,8 @@ export class CertProvider {
       );
       for (const userConfig of userConfigs) {
         try {
-          const mat = await this.loadUserCert(userConfig, globalStoreOptIn);
-          if (mat) certs.push(mat);
+          const entry = await this.loadUserCert(userConfig, globalStoreOptIn);
+          if (entry) certs.push(entry);
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);
           log(
@@ -119,21 +169,18 @@ export class CertProvider {
       }
     }
 
-    return { certs };
-  }
-
-  clearCache(): void {
-    this.cachedDotNet = null;
-    this.cachedUser.clear();
-    this.warnedExpiredCerts.clear();
+    return certs;
   }
 
   private async ensureDotNetDevCert(
     autoProvision: boolean
-  ): Promise<CertMaterialV2 | null> {
+  ): Promise<CachedCert | null> {
     if (this.cachedDotNet) {
       const status = await this.certManager.check();
-      if (status.exists && status.thumbprint === this.cachedDotNet.thumbprint) {
+      if (
+        status.exists &&
+        status.thumbprint === this.cachedDotNet.v3.thumbprint
+      ) {
         return this.cachedDotNet;
       }
       this.cachedDotNet = null;
@@ -171,24 +218,37 @@ export class CertProvider {
       // home is the .NET store, so `pfxBase64` and `dotNetStorePfxBase64`
       // share the same bytes — there's no consent decision to make here.
       const pfxBase64 = fs.readFileSync(pfxPath).toString("base64");
-      const material: CertMaterialV2 = {
+      const pemCertBase64 = fs.readFileSync(pemCertPath).toString("base64");
+      const pemKeyBase64 = fs.readFileSync(pemKeyPath).toString("base64");
+      const rootPfxBase64 = fs.readFileSync(rootPfxPath).toString("base64");
+      const thumbprint = updatedStatus.thumbprint!;
+      const v3: CertMaterialV3 = {
         kind: "dotnet-dev",
         name: DOTNET_DEV_CERT_NAME,
-        thumbprint: updatedStatus.thumbprint!,
+        thumbprint,
         pfxBase64,
-        pemCertBase64: fs.readFileSync(pemCertPath).toString("base64"),
-        pemKeyBase64: fs.readFileSync(pemKeyPath).toString("base64"),
-        rootPfxBase64: fs.readFileSync(rootPfxPath).toString("base64"),
+        pemCertBase64,
+        pemKeyBase64,
+        rootPfxBase64,
         trustInContainer: true,
         installToDotNetStore: true,
         dotNetStorePfxBase64: pfxBase64,
       };
+      const v2: CertMaterialV2 = {
+        kind: "dotnet-dev",
+        name: DOTNET_DEV_CERT_NAME,
+        thumbprint,
+        pfxBase64,
+        pemCertBase64,
+        pemKeyBase64,
+        rootPfxBase64,
+        trustInContainer: true,
+      };
+      const entry: CachedCert = { v3, v2 };
 
-      this.cachedDotNet = material;
-      log(
-        `Dotnet dev cert material ready. Thumbprint: ${material.thumbprint}`
-      );
-      return material;
+      this.cachedDotNet = entry;
+      log(`Dotnet dev cert material ready. Thumbprint: ${thumbprint}`);
+      return entry;
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -197,7 +257,7 @@ export class CertProvider {
   private async loadUserCert(
     config: UserCertificateConfig,
     globalStoreOptIn: boolean
-  ): Promise<CertMaterialV2 | null> {
+  ): Promise<CachedCert | null> {
     // Enforced before any filesystem operation — the name is used directly
     // as a filename stem in the temp export dir, the container trust PEM,
     // and each extra destination. Reject anything that could path-traverse.
@@ -248,35 +308,65 @@ export class CertProvider {
       });
 
       const pfxBase64 = await this.buildUserPfxBase64(loaded, config);
+      // Always compute the passwordless variant when a key is available.
+      // V3 ships it on the wire only when installToDotNetStore is true,
+      // but the V2 downmap needs it unconditionally to keep V2 wire-compat
+      // (passwordless `pfxBase64` always).
+      const passwordlessPfxBase64 = loaded.key
+        ? (await buildPfx({ cert: loaded.cert, key: loaded.key })).toString(
+            "base64"
+          )
+        : undefined;
       const dotNetStorePfxBase64 = installToDotNetStore
-        ? await this.buildPasswordlessStorePfxBase64(loaded, config)
+        ? passwordlessPfxBase64
         : undefined;
 
-      const material: CertMaterialV2 = {
+      const pemCertBase64 = fs
+        .readFileSync(exported.pemCertPath)
+        .toString("base64");
+      const pemKeyBase64 = exported.pemKeyPath
+        ? fs.readFileSync(exported.pemKeyPath).toString("base64")
+        : undefined;
+      const rootPfxBase64 = exported.rootPfxPath
+        ? fs.readFileSync(exported.rootPfxPath).toString("base64")
+        : undefined;
+
+      const v3: CertMaterialV3 = {
         kind: "user",
         name: config.name,
         thumbprint: loaded.thumbprint,
-        pemCertBase64: fs
-          .readFileSync(exported.pemCertPath)
-          .toString("base64"),
-        pemKeyBase64: exported.pemKeyPath
-          ? fs.readFileSync(exported.pemKeyPath).toString("base64")
-          : undefined,
+        pemCertBase64,
+        pemKeyBase64,
         pfxBase64,
-        rootPfxBase64: exported.rootPfxPath
-          ? fs.readFileSync(exported.rootPfxPath).toString("base64")
-          : undefined,
+        rootPfxBase64,
         trustInContainer,
         installToDotNetStore,
         dotNetStorePfxBase64,
       };
 
-      this.cachedUser.set(cacheKey, material);
+      const v2: CertMaterialV2 = {
+        kind: "user",
+        name: config.name,
+        thumbprint: loaded.thumbprint,
+        pemCertBase64,
+        pemKeyBase64,
+        // The V2 wire contract is "passwordless pfxBase64 always" — V2
+        // consumers wrote these bytes directly to the .NET store, which
+        // requires passwordless. The user's password (when supplied) is
+        // therefore stripped on the V2 wire; V3 consumers get the
+        // password-preserving copy via `v3.pfxBase64` instead.
+        pfxBase64: passwordlessPfxBase64,
+        rootPfxBase64,
+        trustInContainer,
+      };
+
+      const entry: CachedCert = { v3, v2 };
+      this.cachedUser.set(cacheKey, entry);
       log(
-        `User cert '${config.name}' ready. Thumbprint: ${material.thumbprint}; ` +
+        `User cert '${config.name}' ready. Thumbprint: ${v3.thumbprint}; ` +
           `installToDotNetStore=${installToDotNetStore}`
       );
-      return material;
+      return entry;
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -306,28 +396,6 @@ export class CertProvider {
       key: loaded.key,
       password: config.pfxPassword ?? "",
     });
-    return bytes.toString("base64");
-  }
-
-  /**
-   * Build the passwordless PFX bytes that get written to the .NET X509Store.
-   * `StoreName.My` enumeration on Linux opens each file with a null password,
-   * so the store copy *must* be passwordless — this is the consented strip
-   * the user opted into via `installUserCertsToDotNetStore`. We never write
-   * these bytes anywhere else (`pfxBase64` carries the password-preserving
-   * payload for everything else).
-   */
-  private async buildPasswordlessStorePfxBase64(
-    loaded: LoadedCert,
-    config: UserCertificateConfig
-  ): Promise<string | undefined> {
-    if (!loaded.key) {
-      log(
-        `User cert '${config.name}' has no private key; skipping X509Store install.`
-      );
-      return undefined;
-    }
-    const bytes = await buildPfx({ cert: loaded.cert, key: loaded.key });
     return bytes.toString("base64");
   }
 

--- a/src/vscode-ui-extension/src/certProvider.ts
+++ b/src/vscode-ui-extension/src/certProvider.ts
@@ -6,6 +6,7 @@ import { type CertManager } from "./cert/manager";
 import { exportLoadedCert } from "./cert/exporter";
 import { loadPemPair, loadPfx } from "./cert/loader";
 import type { LoadedCert } from "./cert/loader";
+import { buildPfx } from "./cert/pfx";
 import { assertValidCertName, log } from "@devcontainer-dev-certs/shared";
 import type {
   CertBundle,
@@ -21,6 +22,7 @@ export interface UserCertificateConfig {
   pemCertPath?: string;
   pemKeyPath?: string;
   trustInContainer?: boolean;
+  excludeFromDotNetStore?: boolean;
 }
 
 export interface GetAllCertMaterialArgs {
@@ -93,9 +95,13 @@ export class CertProvider {
         "userCertificates",
         []
       );
+      const globalStoreOptIn = config.get<boolean>(
+        "installUserCertsToDotNetStore",
+        false
+      );
       for (const userConfig of userConfigs) {
         try {
-          const mat = await this.loadUserCert(userConfig);
+          const mat = await this.loadUserCert(userConfig, globalStoreOptIn);
           if (mat) certs.push(mat);
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);
@@ -161,15 +167,21 @@ export class CertProvider {
 
       const updatedStatus = await this.certManager.check();
 
+      // The dotnet-dev cert is intrinsically passwordless and its canonical
+      // home is the .NET store, so `pfxBase64` and `dotNetStorePfxBase64`
+      // share the same bytes — there's no consent decision to make here.
+      const pfxBase64 = fs.readFileSync(pfxPath).toString("base64");
       const material: CertMaterialV2 = {
         kind: "dotnet-dev",
         name: DOTNET_DEV_CERT_NAME,
         thumbprint: updatedStatus.thumbprint!,
-        pfxBase64: fs.readFileSync(pfxPath).toString("base64"),
+        pfxBase64,
         pemCertBase64: fs.readFileSync(pemCertPath).toString("base64"),
         pemKeyBase64: fs.readFileSync(pemKeyPath).toString("base64"),
         rootPfxBase64: fs.readFileSync(rootPfxPath).toString("base64"),
         trustInContainer: true,
+        installToDotNetStore: true,
+        dotNetStorePfxBase64: pfxBase64,
       };
 
       this.cachedDotNet = material;
@@ -183,7 +195,8 @@ export class CertProvider {
   }
 
   private async loadUserCert(
-    config: UserCertificateConfig
+    config: UserCertificateConfig,
+    globalStoreOptIn: boolean
   ): Promise<CertMaterialV2 | null> {
     // Enforced before any filesystem operation — the name is used directly
     // as a filename stem in the temp export dir, the container trust PEM,
@@ -205,7 +218,16 @@ export class CertProvider {
       loaded = loadPemPair(config.pemCertPath!, config.pemKeyPath ?? null);
     }
 
-    const cacheKey = `${config.name}:${loaded.thumbprint}`;
+    const installToDotNetStore =
+      globalStoreOptIn && !config.excludeFromDotNetStore;
+
+    // The cache key includes the resolved store opt-in so toggling the
+    // global setting (or excludeFromDotNetStore on a single cert) rebuilds
+    // the material with the right dotNetStorePfxBase64 presence rather
+    // than serving a stale entry from before the toggle.
+    const cacheKey = `${config.name}:${loaded.thumbprint}:${
+      installToDotNetStore ? "store" : "nostore"
+    }`;
     const cached = this.cachedUser.get(cacheKey);
     if (cached) return cached;
 
@@ -225,6 +247,11 @@ export class CertProvider {
         includeRootPfx: trustInContainer,
       });
 
+      const pfxBase64 = await this.buildUserPfxBase64(loaded, config);
+      const dotNetStorePfxBase64 = installToDotNetStore
+        ? await this.buildPasswordlessStorePfxBase64(loaded, config)
+        : undefined;
+
       const material: CertMaterialV2 = {
         kind: "user",
         name: config.name,
@@ -235,23 +262,80 @@ export class CertProvider {
         pemKeyBase64: exported.pemKeyPath
           ? fs.readFileSync(exported.pemKeyPath).toString("base64")
           : undefined,
-        pfxBase64: exported.pfxPath
-          ? fs.readFileSync(exported.pfxPath).toString("base64")
-          : undefined,
+        pfxBase64,
         rootPfxBase64: exported.rootPfxPath
           ? fs.readFileSync(exported.rootPfxPath).toString("base64")
           : undefined,
         trustInContainer,
+        installToDotNetStore,
+        dotNetStorePfxBase64,
       };
 
       this.cachedUser.set(cacheKey, material);
       log(
-        `User cert '${config.name}' ready. Thumbprint: ${material.thumbprint}`
+        `User cert '${config.name}' ready. Thumbprint: ${material.thumbprint}; ` +
+          `installToDotNetStore=${installToDotNetStore}; ` +
+          `pfxBase64=${pfxBase64 ? "present" : "omitted"}`
       );
       return material;
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  }
+
+  /**
+   * Build the password-preserving PFX bytes for a user cert. PFX-sourced
+   * entries pass through their original file bytes verbatim — no decrypt /
+   * re-encrypt round-trip, so the user's password (including its absence)
+   * survives untouched. PEM-sourced entries are synthesized only when the
+   * user provided `pfxPassword`; without it we omit `pfxBase64` rather than
+   * silently producing a passwordless PFX. Empty string is treated as a
+   * deliberate "I want a passwordless PFX" signal and produces one.
+   */
+  private async buildUserPfxBase64(
+    loaded: LoadedCert,
+    config: UserCertificateConfig
+  ): Promise<string | undefined> {
+    if (config.pfxPath) {
+      return fs.readFileSync(config.pfxPath).toString("base64");
+    }
+    if (!loaded.key) return undefined;
+    if (config.pfxPassword === undefined) {
+      log(
+        `User cert '${config.name}': pemCertPath source with no pfxPassword; ` +
+          `omitting pfxBase64. Set pfxPassword (use "" for an explicit empty ` +
+          `password) to opt into PFX synthesis for extra destinations.`
+      );
+      return undefined;
+    }
+    const bytes = await buildPfx({
+      cert: loaded.cert,
+      key: loaded.key,
+      password: config.pfxPassword,
+    });
+    return bytes.toString("base64");
+  }
+
+  /**
+   * Build the passwordless PFX bytes that get written to the .NET X509Store.
+   * `StoreName.My` enumeration on Linux opens each file with a null password,
+   * so the store copy *must* be passwordless — this is the consented strip
+   * the user opted into via `installUserCertsToDotNetStore`. We never write
+   * these bytes anywhere else (`pfxBase64` carries the password-preserving
+   * payload for everything else).
+   */
+  private async buildPasswordlessStorePfxBase64(
+    loaded: LoadedCert,
+    config: UserCertificateConfig
+  ): Promise<string | undefined> {
+    if (!loaded.key) {
+      log(
+        `User cert '${config.name}' has no private key; skipping X509Store install.`
+      );
+      return undefined;
+    }
+    const bytes = await buildPfx({ cert: loaded.cert, key: loaded.key });
+    return bytes.toString("base64");
   }
 
   private warnExpired(name: string, notAfter: Date): void {

--- a/src/vscode-ui-extension/src/extension.ts
+++ b/src/vscode-ui-extension/src/extension.ts
@@ -12,7 +12,7 @@ import {
   getOpenSslTrustDir,
   getPemFileName,
 } from "@devcontainer-dev-certs/shared";
-import type { CertBundle } from "@devcontainer-dev-certs/shared";
+import type { CertBundle, CertBundleV3 } from "@devcontainer-dev-certs/shared";
 
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(initLogger("Dev Container Dev Certs"));
@@ -79,45 +79,81 @@ export function activate(context: vscode.ExtensionContext): void {
     )
   );
 
-  // Multi-cert command: supports dotnet-dev opt-out and user-managed certs.
+  // Shared resolution + provisioning flow for the V2 and V3 multi-cert
+  // endpoints. Each endpoint differs only in the bundle shape it returns;
+  // the consent prompt, host-setting gating, and certProvider dispatch all
+  // live here so we don't drift between versions.
+  const resolveAndProvision = async (
+    args: GetAllCertMaterialArgs | undefined
+  ): Promise<GetAllCertMaterialArgs> => {
+    const autoProvisionCfg = vscode.workspace
+      .getConfiguration("devcontainer-dev-certs")
+      .get<boolean>("autoProvision", true);
+    const hostWantsDotNet = vscode.workspace
+      .getConfiguration("devcontainerDevCerts")
+      .get<boolean>("generateDotNetCert", true);
+
+    const decision = await resolveDotnetProvisioning({
+      args,
+      hostWantsDotNet,
+      autoProvision: autoProvisionCfg,
+      checkCert: () => certManager.check(),
+      hasPriorConsent: () =>
+        context.globalState.get<boolean>("certProvisionConsented") === true,
+      recordConsent: () =>
+        context.globalState.update("certProvisionConsented", true),
+      promptUser: promptForCertConsent,
+    });
+
+    return {
+      includeDotNetDev: decision.includeDotNetDev,
+      includeUserCerts: decision.effectiveArgs.includeUserCerts,
+    };
+  };
+
+  // V2 multi-cert command (legacy). Kept for workspace extensions pinned to
+  // the V2 wire contract — passwordless pfxBase64, no installToDotNetStore
+  // flag. New workspaces should call the V3 command below.
   context.subscriptions.push(
     vscode.commands.registerCommand(
       "devcontainer-dev-certs.getAllCertMaterial",
       async (args: GetAllCertMaterialArgs | undefined): Promise<CertBundle> => {
         try {
-          const autoProvisionCfg = vscode.workspace
-            .getConfiguration("devcontainer-dev-certs")
-            .get<boolean>("autoProvision", true);
-          const hostWantsDotNet = vscode.workspace
-            .getConfiguration("devcontainerDevCerts")
-            .get<boolean>("generateDotNetCert", true);
-
-          const decision = await resolveDotnetProvisioning({
-            args,
-            hostWantsDotNet,
-            autoProvision: autoProvisionCfg,
-            checkCert: () => certManager.check(),
-            hasPriorConsent: () =>
-              context.globalState.get<boolean>("certProvisionConsented") ===
-              true,
-            recordConsent: () =>
-              context.globalState.update("certProvisionConsented", true),
-            promptUser: promptForCertConsent,
-          });
-
-          const bundle = await certProvider.getAllCertMaterial({
-            includeDotNetDev: decision.includeDotNetDev,
-            includeUserCerts: decision.effectiveArgs.includeUserCerts,
-          });
-
+          const effective = await resolveAndProvision(args);
+          const bundle = await certProvider.getAllCertMaterial(effective);
           if (bundle.certs.some((c) => c.kind === "dotnet-dev")) {
             ensureTerminalSslCertDir(context);
           }
-
           return bundle;
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);
           log(`Error providing certificate bundle: ${message}`);
+          throw err;
+        }
+      }
+    )
+  );
+
+  // V3 multi-cert command. Returns password-preserving pfxBase64 alongside
+  // an installToDotNetStore flag (and a separate passwordless payload when
+  // the cert opted in). The workspace extension reads V3 directly so it
+  // never has to write password-stripped bytes to disk without consent.
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "devcontainer-dev-certs.getAllCertMaterialV3",
+      async (
+        args: GetAllCertMaterialArgs | undefined
+      ): Promise<CertBundleV3> => {
+        try {
+          const effective = await resolveAndProvision(args);
+          const bundle = await certProvider.getAllCertMaterialV3(effective);
+          if (bundle.certs.some((c) => c.kind === "dotnet-dev")) {
+            ensureTerminalSslCertDir(context);
+          }
+          return bundle;
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          log(`Error providing certificate bundle (V3): ${message}`);
           throw err;
         }
       }

--- a/src/vscode-ui-extension/tests/certProvider.test.ts
+++ b/src/vscode-ui-extension/tests/certProvider.test.ts
@@ -6,7 +6,7 @@ import { CertProvider } from "../src/certProvider";
 import type { UserCertificateConfig } from "../src/certProvider";
 import { exportPem } from "../src/cert/exporter";
 import { generateCertificate } from "../src/cert/generator";
-import { buildPfx } from "../src/cert/pfx";
+import { buildPfx, parsePfx } from "../src/cert/pfx";
 import { VALIDITY_DAYS } from "../src/cert/properties";
 import type { CertManager } from "../src/cert/manager";
 import { type DevCert, type DevKey } from "../src/cert/types";
@@ -122,9 +122,6 @@ describe("CertProvider.getAllCertMaterial", () => {
         name: "corp-ca",
         pemCertPath: tmp.certPath,
         pemKeyPath: tmp.keyPath,
-        // Explicit empty string opts into a passwordless PFX, matching the
-        // new "no pfxPassword → no .pfx" contract for PEM-sourced entries.
-        pfxPassword: "",
       },
     ];
     __setConfig("devcontainerDevCerts", { userCertificates: userConfigs });
@@ -285,14 +282,18 @@ describe("CertProvider.getAllCertMaterial", () => {
     expect(first.certs[0]).toBe(second.certs[0]);
   });
 
-  it("omits pfxBase64 for PEM-source certs with no pfxPassword", async () => {
+  it("synthesizes a passwordless PFX for PEM-source certs with no pfxPassword", async () => {
+    // The source PEM key file is unencrypted on disk; emitting a passwordless
+    // PFX from it doesn't reduce the security posture (nothing to strip).
+    // This differs from the PFX-source path, where an unset password would
+    // mean the source file itself is passwordless.
     const { cert, key } = await makeValidCert();
     const tmp = writeCertFiles(cert, key);
     cleanupDirs.push(tmp.dir);
 
     __setConfig("devcontainerDevCerts", {
       userCertificates: [
-        { name: "no-pfx", pemCertPath: tmp.certPath, pemKeyPath: tmp.keyPath },
+        { name: "synth", pemCertPath: tmp.certPath, pemKeyPath: tmp.keyPath },
       ] satisfies UserCertificateConfig[],
     });
 
@@ -303,8 +304,12 @@ describe("CertProvider.getAllCertMaterial", () => {
     });
 
     expect(bundle.certs).toHaveLength(1);
-    expect(bundle.certs[0].pfxBase64).toBeUndefined();
-    expect(bundle.certs[0].pemKeyBase64).toBeTruthy();
+    expect(bundle.certs[0].pfxBase64).toBeTruthy();
+    const wireBytes = Buffer.from(bundle.certs[0].pfxBase64!, "base64");
+    // Sanity: the bytes are a real PFX that opens with the empty password.
+    const parsed = await parsePfx(wireBytes, "");
+    expect(parsed.cert).toBeTruthy();
+    expect(parsed.key).toBeTruthy();
   });
 
   it("respects installUserCertsToDotNetStore=true for user certs", async () => {

--- a/src/vscode-ui-extension/tests/certProvider.test.ts
+++ b/src/vscode-ui-extension/tests/certProvider.test.ts
@@ -6,6 +6,7 @@ import { CertProvider } from "../src/certProvider";
 import type { UserCertificateConfig } from "../src/certProvider";
 import { exportPem } from "../src/cert/exporter";
 import { generateCertificate } from "../src/cert/generator";
+import { buildPfx } from "../src/cert/pfx";
 import { VALIDITY_DAYS } from "../src/cert/properties";
 import type { CertManager } from "../src/cert/manager";
 import { type DevCert, type DevKey } from "../src/cert/types";
@@ -121,6 +122,9 @@ describe("CertProvider.getAllCertMaterial", () => {
         name: "corp-ca",
         pemCertPath: tmp.certPath,
         pemKeyPath: tmp.keyPath,
+        // Explicit empty string opts into a passwordless PFX, matching the
+        // new "no pfxPassword → no .pfx" contract for PEM-sourced entries.
+        pfxPassword: "",
       },
     ];
     __setConfig("devcontainerDevCerts", { userCertificates: userConfigs });
@@ -138,6 +142,8 @@ describe("CertProvider.getAllCertMaterial", () => {
     expect(bundle.certs[0].pfxBase64).toBeTruthy();
     expect(bundle.certs[0].pemKeyBase64).toBeTruthy();
     expect(bundle.certs[0].rootPfxBase64).toBeTruthy();
+    expect(bundle.certs[0].installToDotNetStore).toBe(false);
+    expect(bundle.certs[0].dotNetStorePfxBase64).toBeUndefined();
   });
 
   it("returns both dotnet-dev and user certs when both enabled", async () => {
@@ -277,6 +283,166 @@ describe("CertProvider.getAllCertMaterial", () => {
       includeUserCerts: true,
     });
     expect(first.certs[0]).toBe(second.certs[0]);
+  });
+
+  it("omits pfxBase64 for PEM-source certs with no pfxPassword", async () => {
+    const { cert, key } = await makeValidCert();
+    const tmp = writeCertFiles(cert, key);
+    cleanupDirs.push(tmp.dir);
+
+    __setConfig("devcontainerDevCerts", {
+      userCertificates: [
+        { name: "no-pfx", pemCertPath: tmp.certPath, pemKeyPath: tmp.keyPath },
+      ] satisfies UserCertificateConfig[],
+    });
+
+    const provider = new CertProvider(mockManager("DOTNET-THUMB"));
+    const bundle = await provider.getAllCertMaterial({
+      includeDotNetDev: false,
+      includeUserCerts: true,
+    });
+
+    expect(bundle.certs).toHaveLength(1);
+    expect(bundle.certs[0].pfxBase64).toBeUndefined();
+    expect(bundle.certs[0].pemKeyBase64).toBeTruthy();
+  });
+
+  it("respects installUserCertsToDotNetStore=true for user certs", async () => {
+    const { cert, key } = await makeValidCert();
+    const tmp = writeCertFiles(cert, key);
+    cleanupDirs.push(tmp.dir);
+
+    __setConfig("devcontainerDevCerts", {
+      installUserCertsToDotNetStore: true,
+      userCertificates: [
+        {
+          name: "kept",
+          pemCertPath: tmp.certPath,
+          pemKeyPath: tmp.keyPath,
+          pfxPassword: "secret",
+        },
+        {
+          name: "exempt",
+          pemCertPath: tmp.certPath,
+          pemKeyPath: tmp.keyPath,
+          pfxPassword: "secret",
+          excludeFromDotNetStore: true,
+        },
+      ] satisfies UserCertificateConfig[],
+    });
+
+    const provider = new CertProvider(mockManager("DOTNET-THUMB"));
+    const bundle = await provider.getAllCertMaterial({
+      includeDotNetDev: false,
+      includeUserCerts: true,
+    });
+
+    const kept = bundle.certs.find((c) => c.name === "kept")!;
+    const exempt = bundle.certs.find((c) => c.name === "exempt")!;
+
+    expect(kept.installToDotNetStore).toBe(true);
+    expect(kept.dotNetStorePfxBase64).toBeTruthy();
+    // The store copy MUST be distinct from pfxBase64 — the latter preserves
+    // the user's password; the former is the consented passwordless copy.
+    expect(kept.dotNetStorePfxBase64).not.toBe(kept.pfxBase64);
+
+    expect(exempt.installToDotNetStore).toBe(false);
+    expect(exempt.dotNetStorePfxBase64).toBeUndefined();
+  });
+
+  it("ignores excludeFromDotNetStore when the global setting is off", async () => {
+    const { cert, key } = await makeValidCert();
+    const tmp = writeCertFiles(cert, key);
+    cleanupDirs.push(tmp.dir);
+
+    __setConfig("devcontainerDevCerts", {
+      installUserCertsToDotNetStore: false,
+      userCertificates: [
+        {
+          name: "noop",
+          pemCertPath: tmp.certPath,
+          pemKeyPath: tmp.keyPath,
+          pfxPassword: "secret",
+          excludeFromDotNetStore: true,
+        },
+      ] satisfies UserCertificateConfig[],
+    });
+
+    const provider = new CertProvider(mockManager("DOTNET-THUMB"));
+    const bundle = await provider.getAllCertMaterial({
+      includeDotNetDev: false,
+      includeUserCerts: true,
+    });
+
+    expect(bundle.certs[0].installToDotNetStore).toBe(false);
+    expect(bundle.certs[0].dotNetStorePfxBase64).toBeUndefined();
+  });
+
+  it("rebuilds cached material when the global store opt-in toggles", async () => {
+    const { cert, key } = await makeValidCert();
+    const tmp = writeCertFiles(cert, key);
+    cleanupDirs.push(tmp.dir);
+
+    const userCertificates: UserCertificateConfig[] = [
+      {
+        name: "toggled",
+        pemCertPath: tmp.certPath,
+        pemKeyPath: tmp.keyPath,
+        pfxPassword: "secret",
+      },
+    ];
+
+    const provider = new CertProvider(mockManager("DOTNET-THUMB"));
+
+    __setConfig("devcontainerDevCerts", {
+      installUserCertsToDotNetStore: false,
+      userCertificates,
+    });
+    const off = await provider.getAllCertMaterial({
+      includeDotNetDev: false,
+      includeUserCerts: true,
+    });
+    expect(off.certs[0].installToDotNetStore).toBe(false);
+    expect(off.certs[0].dotNetStorePfxBase64).toBeUndefined();
+
+    __setConfig("devcontainerDevCerts", {
+      installUserCertsToDotNetStore: true,
+      userCertificates,
+    });
+    const on = await provider.getAllCertMaterial({
+      includeDotNetDev: false,
+      includeUserCerts: true,
+    });
+    expect(on.certs[0].installToDotNetStore).toBe(true);
+    expect(on.certs[0].dotNetStorePfxBase64).toBeTruthy();
+  });
+
+  it("transmits PFX-source bytes verbatim without re-encoding", async () => {
+    // Use a real PFX with a known password so we can prove the bytes
+    // round-trip the IPC unchanged — no decrypt/re-encrypt strip.
+    const { cert, key } = await makeValidCert();
+    const password = "round-trip-secret";
+    const sourceBytes = await buildPfx({ cert, key, password });
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "devcerts-cp-pfx-"));
+    cleanupDirs.push(dir);
+    const pfxPath = path.join(dir, "source.pfx");
+    fs.writeFileSync(pfxPath, sourceBytes);
+
+    __setConfig("devcontainerDevCerts", {
+      userCertificates: [
+        { name: "verbatim", pfxPath, pfxPassword: password },
+      ] satisfies UserCertificateConfig[],
+    });
+
+    const provider = new CertProvider(mockManager("DOTNET-THUMB"));
+    const bundle = await provider.getAllCertMaterial({
+      includeDotNetDev: false,
+      includeUserCerts: true,
+    });
+
+    const wireBytes = Buffer.from(bundle.certs[0].pfxBase64!, "base64");
+    expect(wireBytes.equals(sourceBytes)).toBe(true);
   });
 
   it("supports user certs with ECDSA keys", async () => {

--- a/src/vscode-ui-extension/tests/certProvider.test.ts
+++ b/src/vscode-ui-extension/tests/certProvider.test.ts
@@ -139,8 +139,6 @@ describe("CertProvider.getAllCertMaterial", () => {
     expect(bundle.certs[0].pfxBase64).toBeTruthy();
     expect(bundle.certs[0].pemKeyBase64).toBeTruthy();
     expect(bundle.certs[0].rootPfxBase64).toBeTruthy();
-    expect(bundle.certs[0].installToDotNetStore).toBe(false);
-    expect(bundle.certs[0].dotNetStorePfxBase64).toBeUndefined();
   });
 
   it("returns both dotnet-dev and user certs when both enabled", async () => {
@@ -337,7 +335,7 @@ describe("CertProvider.getAllCertMaterial", () => {
     });
 
     const provider = new CertProvider(mockManager("DOTNET-THUMB"));
-    const bundle = await provider.getAllCertMaterial({
+    const bundle = await provider.getAllCertMaterialV3({
       includeDotNetDev: false,
       includeUserCerts: true,
     });
@@ -374,7 +372,7 @@ describe("CertProvider.getAllCertMaterial", () => {
     });
 
     const provider = new CertProvider(mockManager("DOTNET-THUMB"));
-    const bundle = await provider.getAllCertMaterial({
+    const bundle = await provider.getAllCertMaterialV3({
       includeDotNetDev: false,
       includeUserCerts: true,
     });
@@ -403,7 +401,7 @@ describe("CertProvider.getAllCertMaterial", () => {
       installUserCertsToDotNetStore: false,
       userCertificates,
     });
-    const off = await provider.getAllCertMaterial({
+    const off = await provider.getAllCertMaterialV3({
       includeDotNetDev: false,
       includeUserCerts: true,
     });
@@ -414,7 +412,7 @@ describe("CertProvider.getAllCertMaterial", () => {
       installUserCertsToDotNetStore: true,
       userCertificates,
     });
-    const on = await provider.getAllCertMaterial({
+    const on = await provider.getAllCertMaterialV3({
       includeDotNetDev: false,
       includeUserCerts: true,
     });
@@ -422,9 +420,11 @@ describe("CertProvider.getAllCertMaterial", () => {
     expect(on.certs[0].dotNetStorePfxBase64).toBeTruthy();
   });
 
-  it("transmits PFX-source bytes verbatim without re-encoding", async () => {
+  it("transmits PFX-source bytes verbatim on V3 without re-encoding", async () => {
     // Use a real PFX with a known password so we can prove the bytes
-    // round-trip the IPC unchanged — no decrypt/re-encrypt strip.
+    // round-trip the V3 IPC unchanged — no decrypt/re-encrypt strip.
+    // The V2 wire contract still forces passwordless bytes; that's the
+    // tradeoff for keeping V2 consumers working.
     const { cert, key } = await makeValidCert();
     const password = "round-trip-secret";
     const sourceBytes = await buildPfx({ cert, key, password });
@@ -441,13 +441,24 @@ describe("CertProvider.getAllCertMaterial", () => {
     });
 
     const provider = new CertProvider(mockManager("DOTNET-THUMB"));
-    const bundle = await provider.getAllCertMaterial({
+    const v3 = await provider.getAllCertMaterialV3({
       includeDotNetDev: false,
       includeUserCerts: true,
     });
+    const v3Bytes = Buffer.from(v3.certs[0].pfxBase64!, "base64");
+    expect(v3Bytes.equals(sourceBytes)).toBe(true);
 
-    const wireBytes = Buffer.from(bundle.certs[0].pfxBase64!, "base64");
-    expect(wireBytes.equals(sourceBytes)).toBe(true);
+    // V2 endpoint, by contrast, strips the password (passwordless wire
+    // contract). The bytes differ, but still describe the same cert+key.
+    const v2 = await provider.getAllCertMaterial({
+      includeDotNetDev: false,
+      includeUserCerts: true,
+    });
+    const v2Bytes = Buffer.from(v2.certs[0].pfxBase64!, "base64");
+    expect(v2Bytes.equals(sourceBytes)).toBe(false);
+    const v2Parsed = await parsePfx(v2Bytes, "");
+    expect(v2Parsed.cert).toBeTruthy();
+    expect(v2Parsed.key).toBeTruthy();
   });
 
   it("supports user certs with ECDSA keys", async () => {

--- a/src/vscode-ui-extension/tests/exportLoadedCert.test.ts
+++ b/src/vscode-ui-extension/tests/exportLoadedCert.test.ts
@@ -28,7 +28,7 @@ afterEach(() => {
 });
 
 describe("exportLoadedCert", () => {
-  it("writes pem, key, pfx, and root pfx when includeRootPfx is true", async () => {
+  it("writes pem, key, and root pfx when includeRootPfx is true", async () => {
     const { cert, key } = await makeTestCert();
     const exportDir = tmpDir();
     cleanupDirs.push(exportDir);
@@ -43,15 +43,16 @@ describe("exportLoadedCert", () => {
 
     expect(result.pemCertPath).toBe(path.join(outDir, "corp-ca.pem"));
     expect(result.pemKeyPath).toBe(path.join(outDir, "corp-ca.key"));
-    expect(result.pfxPath).toBe(path.join(outDir, "corp-ca.pfx"));
     expect(result.rootPfxPath).toBe(path.join(outDir, "corp-ca-root.pfx"));
     expect(fs.existsSync(result.pemCertPath)).toBe(true);
     expect(fs.existsSync(result.pemKeyPath!)).toBe(true);
-    expect(fs.existsSync(result.pfxPath!)).toBe(true);
     expect(fs.existsSync(result.rootPfxPath!)).toBe(true);
+    // PFX-with-key synthesis intentionally moved out of exportLoadedCert
+    // so the password decision lives next to pfxPassword in certProvider.
+    expect(fs.existsSync(path.join(outDir, "corp-ca.pfx"))).toBe(false);
   });
 
-  it("skips PFX artifacts when the loaded cert has no private key", async () => {
+  it("skips PEM key when the loaded cert has no private key", async () => {
     const { cert, key } = await makeTestCert();
     const exportDir = tmpDir();
     cleanupDirs.push(exportDir);
@@ -64,12 +65,11 @@ describe("exportLoadedCert", () => {
 
     expect(result.pemCertPath).toBe(path.join(outDir, "ca-only.pem"));
     expect(result.pemKeyPath).toBeNull();
-    expect(result.pfxPath).toBeNull();
     expect(result.rootPfxPath).toBeNull();
     expect(fs.existsSync(result.pemCertPath)).toBe(true);
   });
 
-  it("round-trips an EC-keyed user cert", async () => {
+  it("writes the PEM artifacts for an EC-keyed cert", async () => {
     const now = new Date();
     const expiry = new Date(now.getTime() + VALIDITY_DAYS * 86400 * 1000);
     const { cert, key } = await generateCertificate(now, expiry, {
@@ -86,6 +86,7 @@ describe("exportLoadedCert", () => {
     cleanupDirs.push(outDir);
     const result = await exportLoadedCert(loaded, "ec-cert", outDir);
 
-    expect(fs.existsSync(result.pfxPath!)).toBe(true);
+    expect(fs.existsSync(result.pemCertPath)).toBe(true);
+    expect(fs.existsSync(result.pemKeyPath!)).toBe(true);
   });
 });

--- a/src/vscode-workspace-extension/package.json
+++ b/src/vscode-workspace-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Dev Container Dev Certificates (Remote)",
   "description": "Receives and installs ASP.NET and Aspire compatible HTTPS development certificates inside Dev Containers and remote environments.",
   "icon": "images/dn_workspace_extension_icon_256.png",
-  "version": "1.1.0-pre",
+  "version": "1.1.0",
   "publisher": "dnegstad",
   "license": "MIT",
   "repository": {

--- a/src/vscode-workspace-extension/src/certInstaller.ts
+++ b/src/vscode-workspace-extension/src/certInstaller.ts
@@ -118,13 +118,24 @@ export function installUserCert(material: CertMaterialV2): void {
   fs.mkdirSync(dotNetRootStoreDir, { recursive: true });
   fs.mkdirSync(trustDir, { recursive: true });
 
-  if (material.pfxBase64) {
-    const pfxPath = path.join(
-      dotNetStoreDir,
-      getPfxFileName(material.thumbprint)
+  const storePath = path.join(
+    dotNetStoreDir,
+    getPfxFileName(material.thumbprint)
+  );
+  if (material.installToDotNetStore && material.dotNetStorePfxBase64) {
+    // The user opted into a plain-text-equivalent copy in the store. The
+    // bytes here are the host-built passwordless re-encode; pfxBase64 (with
+    // the user's password preserved) is for other destinations only.
+    fs.writeFileSync(
+      storePath,
+      Buffer.from(material.dotNetStorePfxBase64, "base64")
     );
-    fs.writeFileSync(pfxPath, Buffer.from(material.pfxBase64, "base64"));
-    chmodSafe(pfxPath, 0o600);
+    chmodSafe(storePath, 0o600);
+  } else {
+    // Sweep stale state — if the user previously opted in and now opted out
+    // (global setting flipped off, or `excludeFromDotNetStore` added), remove
+    // the cached plain-text copy rather than orphaning it.
+    fs.rmSync(storePath, { force: true });
   }
 
   if (material.trustInContainer) {
@@ -179,7 +190,7 @@ export function isCertInstalled(material: CertMaterialV2): boolean {
     );
   }
 
-  if (material.pfxBase64) {
+  if (material.installToDotNetStore) {
     const pfxPath = path.join(
       getDotNetStorePath(),
       getPfxFileName(material.thumbprint)
@@ -244,6 +255,19 @@ export function writeExtraDestination(
     const content = pemKey ? `${pemCert}${pemKey}` : pemCert;
     writeText(pathFor("-bundle.pem"), content, 0o600);
   };
+
+  // Distinguish "user explicitly asked for a .pfx but the host couldn't
+  // provide one" (warn-worthy) from "format=all, no PFX available because
+  // it's a CA-only cert" (silently skipped). Both branches reach writePfx,
+  // but only the explicit-pfx case surfaces a diagnostic.
+  if (dest.format === "pfx" && !pfx) {
+    errors.push(
+      `Cert '${material.name}' has no PFX available — skipping .pfx ` +
+        `destination '${dest.path}'. For PEM-sourced user certs, set ` +
+        `pfxPassword (use "" for an explicit empty password) to opt into ` +
+        `.pfx synthesis.`
+    );
+  }
 
   try {
     switch (dest.format) {

--- a/src/vscode-workspace-extension/src/certInstaller.ts
+++ b/src/vscode-workspace-extension/src/certInstaller.ts
@@ -256,16 +256,13 @@ export function writeExtraDestination(
     writeText(pathFor("-bundle.pem"), content, 0o600);
   };
 
-  // Distinguish "user explicitly asked for a .pfx but the host couldn't
-  // provide one" (warn-worthy) from "format=all, no PFX available because
-  // it's a CA-only cert" (silently skipped). Both branches reach writePfx,
-  // but only the explicit-pfx case surfaces a diagnostic.
+  // For format=pfx specifically, the user asked for a .pfx but the cert has
+  // no private key to put in one (CA-only entry). Surface that as a warning
+  // rather than silently skipping. For format=all the same skip is normal.
   if (dest.format === "pfx" && !pfx) {
     errors.push(
-      `Cert '${material.name}' has no PFX available — skipping .pfx ` +
-        `destination '${dest.path}'. For PEM-sourced user certs, set ` +
-        `pfxPassword (use "" for an explicit empty password) to opt into ` +
-        `.pfx synthesis.`
+      `Cert '${material.name}' has no private key — skipping .pfx ` +
+        `destination '${dest.path}'.`
     );
   }
 

--- a/src/vscode-workspace-extension/src/certInstaller.ts
+++ b/src/vscode-workspace-extension/src/certInstaller.ts
@@ -9,11 +9,15 @@ import {
   getPemFileName,
   getPemFileNameForUser,
 } from "@devcontainer-dev-certs/shared";
-import type { CertMaterialV2 } from "@devcontainer-dev-certs/shared";
+import type { CertMaterialV3 } from "@devcontainer-dev-certs/shared";
 import { createHashSymlink, rehashDirectory } from "./util/rehash";
 import type { ExtraDestination } from "./util/destinations";
 
-export type { CertMaterial, CertMaterialV2 } from "@devcontainer-dev-certs/shared";
+export type {
+  CertMaterial,
+  CertMaterialV2,
+  CertMaterialV3,
+} from "@devcontainer-dev-certs/shared";
 
 function chmodSafe(filePath: string, mode: number): void {
   try {
@@ -28,7 +32,7 @@ function chmodSafe(filePath: string, mode: number): void {
  * OpenSSL trust locations using thumbprint-keyed filenames that Kestrel
  * expects. Byte-identical to the legacy single-cert behavior.
  */
-export function installDotNetDevCert(material: CertMaterialV2): void {
+export function installDotNetDevCert(material: CertMaterialV3): void {
   if (material.kind !== "dotnet-dev") {
     throw new Error(
       `installDotNetDevCert called with non-dotnet-dev cert (kind=${material.kind})`
@@ -99,7 +103,7 @@ export function installDotNetDevCert(material: CertMaterialV2): void {
  * trustInContainer is true the public cert also lands in the .NET Root store
  * and the OpenSSL trust directory under a stable `{name}.pem` filename.
  */
-export function installUserCert(material: CertMaterialV2): void {
+export function installUserCert(material: CertMaterialV3): void {
   if (material.kind !== "user") {
     throw new Error(
       `installUserCert called with non-user cert (kind=${material.kind})`
@@ -169,7 +173,7 @@ export function installUserCert(material: CertMaterialV2): void {
  * the thumbprint-keyed PFX (when applicable) and, when trust is requested,
  * the named PEM exist.
  */
-export function isCertInstalled(material: CertMaterialV2): boolean {
+export function isCertInstalled(material: CertMaterialV3): boolean {
   if (material.kind === "dotnet-dev") {
     const pfxPath = path.join(
       getDotNetStorePath(),
@@ -213,7 +217,7 @@ export function isCertInstalled(material: CertMaterialV2): boolean {
  */
 export function writeExtraDestination(
   dest: ExtraDestination,
-  material: CertMaterialV2
+  material: CertMaterialV3
 ): { rehashDir: string | null; errors: string[] } {
   // The name is used verbatim as a filename stem under the destination dir.
   assertValidCertName(material.name);

--- a/src/vscode-workspace-extension/src/extension.ts
+++ b/src/vscode-workspace-extension/src/extension.ts
@@ -8,16 +8,18 @@ import {
 } from "./certInstaller";
 import { parseExtraCertDestinations } from "./util/destinations";
 import { ensureSslCertDir } from "./util/sslCertDir";
+import { upmapV1ToV3, upmapV2ToV3 } from "./util/upmap";
 import { initLogger, log } from "@devcontainer-dev-certs/shared";
 import type {
   CertBundle,
+  CertBundleV3,
   CertMaterial,
-  CertMaterialV2,
 } from "@devcontainer-dev-certs/shared";
 
 const UI_EXTENSION_ID = "dnegstad.devcontainer-dev-certs-host";
 const GET_CERT_COMMAND = "devcontainer-dev-certs.getCertMaterial";
 const GET_BUNDLE_COMMAND = "devcontainer-dev-certs.getAllCertMaterial";
+const GET_BUNDLE_V3_COMMAND = "devcontainer-dev-certs.getAllCertMaterialV3";
 
 function isTruthyEnv(val: string | undefined, defaultVal: boolean): boolean {
   if (val === undefined || val === "") return defaultVal;
@@ -153,28 +155,60 @@ async function injectCertificate(): Promise<void> {
 async function tryGetBundle(
   includeDotNetDev: boolean,
   includeUserCerts: boolean
-): Promise<CertBundle | null> {
-  // Prefer the v2 multi-cert command.
+): Promise<CertBundleV3 | null> {
+  // Prefer V3. Older host extensions don't know this command; on
+  // "command not found" we fall through to V2 (which they do speak).
   try {
-    log("Calling getAllCertMaterial on UI extension...");
+    log("Calling getAllCertMaterialV3 on UI extension...");
+    const bundle = await vscode.commands.executeCommand<CertBundleV3>(
+      GET_BUNDLE_V3_COMMAND,
+      { includeDotNetDev, includeUserCerts }
+    );
+    if (bundle) return bundle;
+    log(
+      "getAllCertMaterialV3 returned no bundle; falling back to V2 command."
+    );
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes(`command '${GET_BUNDLE_V3_COMMAND}' not found`)) {
+      log(
+        "getAllCertMaterialV3 not available; falling back to V2 command."
+      );
+    } else {
+      log(`Error retrieving cert bundle (V3) from host: ${message}`);
+      vscode.window.showErrorMessage(
+        vscode.l10n.t(
+          "Dev Certs: Failed to obtain certificates from the host machine. Check the Dev Container Dev Certs output on the host for details."
+        )
+      );
+      return null;
+    }
+  }
+
+  // V2 fallback: passwordless pfxBase64, no installToDotNetStore flag.
+  // The host runs this when it's pinned to a pre-V3 version. We upmap each
+  // cert to V3 with conservative defaults — always install to the .NET
+  // store, since that was the V2 wire contract's implicit behavior.
+  try {
+    log("Calling getAllCertMaterial (V2) on UI extension...");
     const bundle = await vscode.commands.executeCommand<CertBundle>(
       GET_BUNDLE_COMMAND,
       { includeDotNetDev, includeUserCerts }
     );
-    if (bundle) return bundle;
-    log("getAllCertMaterial returned no bundle; falling back to legacy command.");
+    if (bundle) {
+      return { certs: bundle.certs.map(upmapV2ToV3) };
+    }
+    log(
+      "getAllCertMaterial returned no bundle; falling back to legacy command."
+    );
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     if (message.includes(`command '${GET_BUNDLE_COMMAND}' not found`)) {
-      // Either the UI extension isn't installed at all or it's pinned to an
-      // older version without v2. Let the legacy fallback sort out which —
-      // if the UI ext isn't installed, the legacy executeCommand will throw
-      // the same "not found" and its handler will prompt to install.
       log(
         "getAllCertMaterial not available; falling back to legacy single-cert command."
       );
     } else {
-      log(`Error retrieving cert bundle from host: ${message}`);
+      log(`Error retrieving cert bundle (V2) from host: ${message}`);
       vscode.window.showErrorMessage(
         vscode.l10n.t(
           "Dev Certs: Failed to obtain certificates from the host machine. Check the Dev Container Dev Certs output on the host for details."
@@ -223,21 +257,7 @@ async function tryGetBundle(
     return null;
   }
 
-  const v2: CertMaterialV2 = {
-    kind: "dotnet-dev",
-    name: "aspnetcore-dev",
-    thumbprint: legacy.thumbprint,
-    pfxBase64: legacy.pfxBase64,
-    pemCertBase64: legacy.pemCertBase64,
-    pemKeyBase64: legacy.pemKeyBase64,
-    rootPfxBase64: legacy.rootPfxBase64,
-    trustInContainer: true,
-    // The legacy IPC only ever returned the dotnet-dev cert, which always
-    // installs to the .NET store (canonical location, no password to strip).
-    installToDotNetStore: true,
-    dotNetStorePfxBase64: legacy.pfxBase64,
-  };
-  return { certs: [v2] };
+  return { certs: [upmapV1ToV3(legacy)] };
 }
 
 async function promptInstallUiExtension(): Promise<void> {

--- a/src/vscode-workspace-extension/src/extension.ts
+++ b/src/vscode-workspace-extension/src/extension.ts
@@ -232,6 +232,10 @@ async function tryGetBundle(
     pemKeyBase64: legacy.pemKeyBase64,
     rootPfxBase64: legacy.rootPfxBase64,
     trustInContainer: true,
+    // The legacy IPC only ever returned the dotnet-dev cert, which always
+    // installs to the .NET store (canonical location, no password to strip).
+    installToDotNetStore: true,
+    dotNetStorePfxBase64: legacy.pfxBase64,
   };
   return { certs: [v2] };
 }

--- a/src/vscode-workspace-extension/src/util/upmap.ts
+++ b/src/vscode-workspace-extension/src/util/upmap.ts
@@ -1,0 +1,48 @@
+import type {
+  CertMaterial,
+  CertMaterialV2,
+  CertMaterialV3,
+} from "@devcontainer-dev-certs/shared";
+
+/**
+ * V2 → V3 upmap. The V2 wire contract was "passwordless `pfxBase64` always,
+ * always written to the .NET X509Store." We carry that forward: any cert
+ * that came across V2 with a PFX still gets installed to the store (so
+ * existing workflows on an older host extension keep working), and the
+ * same passwordless bytes serve as both `pfxBase64` and the store payload.
+ * The V3 consent contract only kicks in when both peers speak V3.
+ */
+export function upmapV2ToV3(material: CertMaterialV2): CertMaterialV3 {
+  return {
+    kind: material.kind,
+    name: material.name,
+    thumbprint: material.thumbprint,
+    pfxBase64: material.pfxBase64,
+    pemCertBase64: material.pemCertBase64,
+    pemKeyBase64: material.pemKeyBase64,
+    rootPfxBase64: material.rootPfxBase64,
+    trustInContainer: material.trustInContainer,
+    installToDotNetStore: material.pfxBase64 !== undefined,
+    dotNetStorePfxBase64: material.pfxBase64,
+  };
+}
+
+/**
+ * V1 → V3 upmap. V1 only ever returned the auto-generated dotnet-dev cert.
+ * That cert always installs to the .NET store — canonical location, no
+ * password either way.
+ */
+export function upmapV1ToV3(legacy: CertMaterial): CertMaterialV3 {
+  return {
+    kind: "dotnet-dev",
+    name: "aspnetcore-dev",
+    thumbprint: legacy.thumbprint,
+    pfxBase64: legacy.pfxBase64,
+    pemCertBase64: legacy.pemCertBase64,
+    pemKeyBase64: legacy.pemKeyBase64,
+    rootPfxBase64: legacy.rootPfxBase64,
+    trustInContainer: true,
+    installToDotNetStore: true,
+    dotNetStorePfxBase64: legacy.pfxBase64,
+  };
+}

--- a/src/vscode-workspace-extension/tests/certInstaller.test.ts
+++ b/src/vscode-workspace-extension/tests/certInstaller.test.ts
@@ -4,7 +4,7 @@ import * as os from "os";
 import * as path from "path";
 import { writeExtraDestination } from "../src/certInstaller";
 import { parseExtraCertDestinations } from "../src/util/destinations";
-import type { CertMaterialV2 } from "@devcontainer-dev-certs/shared";
+import type { CertMaterialV3 } from "@devcontainer-dev-certs/shared";
 
 function tmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "devcerts-ws-test-"));
@@ -18,7 +18,7 @@ afterEach(() => {
   cleanupDirs.length = 0;
 });
 
-function fakeMaterial(name: string): CertMaterialV2 {
+function fakeMaterial(name: string): CertMaterialV3 {
   const pemCert = "-----BEGIN CERTIFICATE-----\nFAKECERT\n-----END CERTIFICATE-----\n";
   const pemKey = "-----BEGIN RSA PRIVATE KEY-----\nFAKEKEY\n-----END RSA PRIVATE KEY-----\n";
   return {
@@ -80,7 +80,7 @@ describe.skipIf(process.platform === "win32")("writeExtraDestination", () => {
     const dir = tmpDir();
     cleanupDirs.push(dir);
 
-    const material: CertMaterialV2 = {
+    const material: CertMaterialV3 = {
       ...fakeMaterial("ca-only"),
       pemKeyBase64: undefined,
       pfxBase64: undefined,
@@ -99,7 +99,7 @@ describe.skipIf(process.platform === "win32")("writeExtraDestination", () => {
     const dir = tmpDir();
     cleanupDirs.push(dir);
 
-    const material: CertMaterialV2 = {
+    const material: CertMaterialV3 = {
       ...fakeMaterial("../evil"),
     };
     const { destinations } = parseExtraCertDestinations(dir);

--- a/src/vscode-workspace-extension/tests/certInstaller.test.ts
+++ b/src/vscode-workspace-extension/tests/certInstaller.test.ts
@@ -29,6 +29,7 @@ function fakeMaterial(name: string): CertMaterialV2 {
     pemKeyBase64: Buffer.from(pemKey).toString("base64"),
     pfxBase64: Buffer.from("PFXBYTES").toString("base64"),
     trustInContainer: true,
+    installToDotNetStore: false,
   };
 }
 

--- a/src/vscode-workspace-extension/tests/installUserCert.test.ts
+++ b/src/vscode-workspace-extension/tests/installUserCert.test.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import type * as Shared from "@devcontainer-dev-certs/shared";
-import type { CertMaterialV2 } from "@devcontainer-dev-certs/shared";
+import type { CertMaterialV3 } from "@devcontainer-dev-certs/shared";
 
 // Sandbox the .NET store / trust-dir paths into per-test temp dirs so the
 // real filesystem locations stay untouched.
@@ -43,7 +43,7 @@ afterEach(() => {
   cleanupDirs.length = 0;
 });
 
-function userMaterial(overrides: Partial<CertMaterialV2> = {}): CertMaterialV2 {
+function userMaterial(overrides: Partial<CertMaterialV3> = {}): CertMaterialV3 {
   return {
     kind: "user",
     name: "corp-ca",
@@ -122,7 +122,7 @@ describe.skipIf(process.platform === "win32")("installUserCert store gating", ()
 
 describe.skipIf(process.platform === "win32")("installDotNetDevCert", () => {
   it("always writes to the store regardless of any opt-in flag", () => {
-    const material: CertMaterialV2 = {
+    const material: CertMaterialV3 = {
       kind: "dotnet-dev",
       name: "aspnetcore-dev",
       thumbprint: "DEADBEEF",

--- a/src/vscode-workspace-extension/tests/installUserCert.test.ts
+++ b/src/vscode-workspace-extension/tests/installUserCert.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import type * as Shared from "@devcontainer-dev-certs/shared";
+import type { CertMaterialV2 } from "@devcontainer-dev-certs/shared";
+
+// Sandbox the .NET store / trust-dir paths into per-test temp dirs so the
+// real filesystem locations stay untouched.
+let storeDir: string;
+let rootStoreDir: string;
+let trustDir: string;
+
+vi.mock("@devcontainer-dev-certs/shared", async (importOriginal) => {
+  const original = await importOriginal<typeof Shared>();
+  return {
+    ...original,
+    getDotNetStorePath: () => storeDir,
+    getDotNetRootStorePath: () => rootStoreDir,
+    getOpenSslTrustDir: () => trustDir,
+  };
+});
+
+import {
+  installUserCert,
+  installDotNetDevCert,
+  isCertInstalled,
+} from "../src/certInstaller";
+
+const cleanupDirs: string[] = [];
+
+beforeEach(() => {
+  storeDir = fs.mkdtempSync(path.join(os.tmpdir(), "devcerts-store-"));
+  rootStoreDir = fs.mkdtempSync(path.join(os.tmpdir(), "devcerts-root-"));
+  trustDir = fs.mkdtempSync(path.join(os.tmpdir(), "devcerts-trust-"));
+  cleanupDirs.push(storeDir, rootStoreDir, trustDir);
+});
+
+afterEach(() => {
+  for (const dir of cleanupDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  cleanupDirs.length = 0;
+});
+
+function userMaterial(overrides: Partial<CertMaterialV2> = {}): CertMaterialV2 {
+  return {
+    kind: "user",
+    name: "corp-ca",
+    thumbprint: "AABBCCDDEEFF",
+    pemCertBase64: Buffer.from(
+      "-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n"
+    ).toString("base64"),
+    pemKeyBase64: Buffer.from(
+      "-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----\n"
+    ).toString("base64"),
+    pfxBase64: Buffer.from("PFX-PRESERVED").toString("base64"),
+    rootPfxBase64: Buffer.from("ROOT-PFX").toString("base64"),
+    trustInContainer: true,
+    installToDotNetStore: false,
+    ...overrides,
+  };
+}
+
+describe.skipIf(process.platform === "win32")("installUserCert store gating", () => {
+  it("does NOT write the store PFX when installToDotNetStore is false", () => {
+    installUserCert(userMaterial({ installToDotNetStore: false }));
+    const storePath = path.join(storeDir, "AABBCCDDEEFF.pfx");
+    expect(fs.existsSync(storePath)).toBe(false);
+    // Trust dir copy still happens because trustInContainer = true.
+    expect(fs.existsSync(path.join(trustDir, "corp-ca.pem"))).toBe(true);
+  });
+
+  it("writes the store PFX with the store-only bytes when opted in", () => {
+    const dotNetStorePfxBase64 = Buffer.from("PFX-PASSWORDLESS").toString(
+      "base64"
+    );
+    installUserCert(
+      userMaterial({
+        installToDotNetStore: true,
+        dotNetStorePfxBase64,
+      })
+    );
+    const storePath = path.join(storeDir, "AABBCCDDEEFF.pfx");
+    expect(fs.existsSync(storePath)).toBe(true);
+    // The store copy carries the passwordless bytes, never the password-
+    // preserving pfxBase64 — the host's separation must propagate to disk.
+    expect(fs.readFileSync(storePath).toString()).toBe("PFX-PASSWORDLESS");
+  });
+
+  it("sweeps a stale store PFX when the opt-in is later cleared", () => {
+    const storePath = path.join(storeDir, "AABBCCDDEEFF.pfx");
+    installUserCert(
+      userMaterial({
+        installToDotNetStore: true,
+        dotNetStorePfxBase64: Buffer.from("OLD").toString("base64"),
+      })
+    );
+    expect(fs.existsSync(storePath)).toBe(true);
+
+    // User flips the global opt-in off (or adds excludeFromDotNetStore on
+    // this entry). On the next sync the workspace MUST remove the stale
+    // plain-text copy, not orphan it.
+    installUserCert(userMaterial({ installToDotNetStore: false }));
+    expect(fs.existsSync(storePath)).toBe(false);
+  });
+
+  it("skips the store write when opt-in is true but bytes are missing", () => {
+    // Defense in depth — host should always pair the flag with bytes, but
+    // workspace gates on both so a malformed IPC payload can't accidentally
+    // strip a write target.
+    installUserCert(
+      userMaterial({
+        installToDotNetStore: true,
+        dotNetStorePfxBase64: undefined,
+      })
+    );
+    const storePath = path.join(storeDir, "AABBCCDDEEFF.pfx");
+    expect(fs.existsSync(storePath)).toBe(false);
+  });
+});
+
+describe.skipIf(process.platform === "win32")("installDotNetDevCert", () => {
+  it("always writes to the store regardless of any opt-in flag", () => {
+    const material: CertMaterialV2 = {
+      kind: "dotnet-dev",
+      name: "aspnetcore-dev",
+      thumbprint: "DEADBEEF",
+      pemCertBase64: Buffer.from(
+        "-----BEGIN CERTIFICATE-----\nDEV\n-----END CERTIFICATE-----\n"
+      ).toString("base64"),
+      pemKeyBase64: Buffer.from(
+        "-----BEGIN PRIVATE KEY-----\nDEV\n-----END PRIVATE KEY-----\n"
+      ).toString("base64"),
+      pfxBase64: Buffer.from("DEV-PFX").toString("base64"),
+      rootPfxBase64: Buffer.from("DEV-ROOT").toString("base64"),
+      trustInContainer: true,
+      installToDotNetStore: true,
+      dotNetStorePfxBase64: Buffer.from("DEV-PFX").toString("base64"),
+    };
+    installDotNetDevCert(material);
+    expect(fs.existsSync(path.join(storeDir, "DEADBEEF.pfx"))).toBe(true);
+    expect(fs.existsSync(path.join(rootStoreDir, "DEADBEEF.pfx"))).toBe(true);
+  });
+});
+
+describe.skipIf(process.platform === "win32")("isCertInstalled", () => {
+  it("returns true for a user cert opted out of the store with no store file", () => {
+    installUserCert(userMaterial({ installToDotNetStore: false }));
+    expect(isCertInstalled(userMaterial({ installToDotNetStore: false }))).toBe(
+      true
+    );
+  });
+
+  it("returns false for an opted-in user cert when the store file is missing", () => {
+    // Only the trust-dir copy was installed (simulate a half-completed install
+    // or a manual deletion). The check should reflect that the store file is
+    // missing.
+    installUserCert(userMaterial({ installToDotNetStore: false }));
+    expect(
+      isCertInstalled(
+        userMaterial({
+          installToDotNetStore: true,
+          dotNetStorePfxBase64: Buffer.from("X").toString("base64"),
+        })
+      )
+    ).toBe(false);
+  });
+});

--- a/src/vscode-workspace-extension/tests/upmap.test.ts
+++ b/src/vscode-workspace-extension/tests/upmap.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import type {
+  CertMaterial,
+  CertMaterialV2,
+} from "@devcontainer-dev-certs/shared";
+import { upmapV1ToV3, upmapV2ToV3 } from "../src/util/upmap";
+
+const PEM_CERT_B64 = Buffer.from(
+  "-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n"
+).toString("base64");
+const PEM_KEY_B64 = Buffer.from(
+  "-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----\n"
+).toString("base64");
+
+describe("upmapV2ToV3", () => {
+  it("preserves V2 wire behavior — installs to store when a PFX is present", () => {
+    const v2: CertMaterialV2 = {
+      kind: "user",
+      name: "corp",
+      thumbprint: "ABCDEF",
+      pfxBase64: Buffer.from("PASSWORDLESS").toString("base64"),
+      pemCertBase64: PEM_CERT_B64,
+      pemKeyBase64: PEM_KEY_B64,
+      rootPfxBase64: Buffer.from("ROOT").toString("base64"),
+      trustInContainer: true,
+    };
+    const v3 = upmapV2ToV3(v2);
+    // V2 was always passwordless and always store-bound; on V3 that's an
+    // implicit `installToDotNetStore: true` and `dotNetStorePfxBase64`
+    // equal to `pfxBase64`.
+    expect(v3.installToDotNetStore).toBe(true);
+    expect(v3.dotNetStorePfxBase64).toBe(v2.pfxBase64);
+    expect(v3.pfxBase64).toBe(v2.pfxBase64);
+    // Pass-through fields.
+    expect(v3.kind).toBe("user");
+    expect(v3.thumbprint).toBe("ABCDEF");
+    expect(v3.trustInContainer).toBe(true);
+    expect(v3.rootPfxBase64).toBe(v2.rootPfxBase64);
+  });
+
+  it("skips store install when V2 carried no PFX (CA-only entry)", () => {
+    const v2: CertMaterialV2 = {
+      kind: "user",
+      name: "ca-only",
+      thumbprint: "ABCDEF",
+      pemCertBase64: PEM_CERT_B64,
+      trustInContainer: true,
+    };
+    const v3 = upmapV2ToV3(v2);
+    expect(v3.installToDotNetStore).toBe(false);
+    expect(v3.dotNetStorePfxBase64).toBeUndefined();
+    expect(v3.pfxBase64).toBeUndefined();
+  });
+
+  it("propagates dotnet-dev kind unchanged", () => {
+    const v2: CertMaterialV2 = {
+      kind: "dotnet-dev",
+      name: "aspnetcore-dev",
+      thumbprint: "DEADBEEF",
+      pfxBase64: Buffer.from("DEV-PFX").toString("base64"),
+      pemCertBase64: PEM_CERT_B64,
+      pemKeyBase64: PEM_KEY_B64,
+      rootPfxBase64: Buffer.from("DEV-ROOT").toString("base64"),
+      trustInContainer: true,
+    };
+    const v3 = upmapV2ToV3(v2);
+    expect(v3.kind).toBe("dotnet-dev");
+    expect(v3.installToDotNetStore).toBe(true);
+  });
+});
+
+describe("upmapV1ToV3", () => {
+  it("treats the legacy dotnet-dev cert as always-install-to-store", () => {
+    const v1: CertMaterial = {
+      thumbprint: "DEADBEEF",
+      pfxBase64: Buffer.from("DEV-PFX").toString("base64"),
+      pemCertBase64: PEM_CERT_B64,
+      pemKeyBase64: PEM_KEY_B64,
+      rootPfxBase64: Buffer.from("DEV-ROOT").toString("base64"),
+    };
+    const v3 = upmapV1ToV3(v1);
+    expect(v3.kind).toBe("dotnet-dev");
+    expect(v3.name).toBe("aspnetcore-dev");
+    expect(v3.installToDotNetStore).toBe(true);
+    expect(v3.dotNetStorePfxBase64).toBe(v1.pfxBase64);
+    expect(v3.trustInContainer).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

This PR introduces a new V3 certificate wire protocol that preserves user PFX passwords end-to-end and adds explicit opt-in control for installing user certificates to the .NET X509Store. The V2 protocol is retained for backward compatibility with older workspace extensions.

## Key Changes

- **New V3 wire protocol** (`CertMaterialV3`, `CertBundleV3`):
  - Adds `installToDotNetStore` flag for per-cert store installation control
  - Adds `dotNetStorePfxBase64` field carrying passwordless bytes only when opted in
  - Preserves user's PFX password in `pfxBase64` for PFX-sourced certs and synthesized PFX for PEM-sourced certs
  - Includes `kind` field to distinguish dotnet-dev from user certs

- **Host-side (UI extension) changes**:
  - `getAllCertMaterialV3()` endpoint returns V3 bundles with password-preserving payloads
  - `getAllCertMaterial()` (V2) downmaps to passwordless bytes for backward compatibility
  - Dual caching via `CachedCert` interface holding both V2 and V3 shapes to avoid recomputation
  - New `buildUserPfxBase64()` method synthesizes PFX from PEM sources with user's password
  - Passwordless variant always computed for V2 downmap compatibility
  - New config options: `installUserCertsToDotNetStore` (global) and `excludeFromDotNetStore` (per-cert)

- **Workspace-side changes**:
  - `installUserCert()` now gates .NET store writes on `installToDotNetStore` flag and `dotNetStorePfxBase64` presence
  - Sweeps stale store files when opt-in is cleared
  - `tryGetBundle()` prefers V3 endpoint, falls back to V2 with upmapping
  - New `upmap.ts` utilities convert V1/V2 to V3 for older host extensions

- **Test coverage**:
  - New `installUserCert.test.ts` validates store gating behavior
  - New `upmap.test.ts` validates V1→V3 and V2→V3 conversion
  - Updated `certProvider.test.ts` with V3-specific scenarios (password preservation, opt-in toggling, PFX round-tripping)

## Implementation Details

- **Password preservation**: PFX-sourced user certs transmit original file bytes verbatim on V3; PEM-sourced certs synthesize a PFX encrypted with `pfxPassword` (or passwordless if unset)
- **Cache key includes opt-in state**: Toggling `installUserCertsToDotNetStore` or `excludeFromDotNetStore` rebuilds cached material with correct `dotNetStorePfxBase64` presence
- **V2 downmap strategy**: V2 consumers always receive passwordless `pfxBase64` (preserving wire contract); the passwordless variant is computed unconditionally and reused for both V2 wire and V3 store payload
- **Dotnet-dev cert**: Intrinsically passwordless; `pfxBase64` and `dotNetStorePfxBase64` share identical bytes; always installs to store
- **Backward compatibility**: V2 endpoint remains unchanged in behavior; V2 consumers via upmap get conservative defaults (always install to store when PFX present)

https://claude.ai/code/session_01GgBLybuRSHreMnvUAcL9E3