### PR TITLE
Refactor dev cert selection to classify and rank candidates

### DIFF
--- a/src/vscode-ui-extension/src/platform/baseStore.ts
+++ b/src/vscode-ui-extension/src/platform/baseStore.ts
@@ -1,8 +1,212 @@
 import * as fs from "fs";
+import * as path from "path";
 import { type PlatformCertificateStore, type CertificateStatus } from "./types";
 import { isValidDevCert, getCertificateVersion } from "../cert/generator";
 import { type DevCert, type DevKey } from "../cert/types";
 import { buildPfx, parsePfx } from "../cert/pfx";
+import { log } from "@devcontainer-dev-certs/shared";
+
+/**
+ * Resolved dev cert + private key that's ready to sync.
+ */
+export interface UsableDevCert {
+  cert: DevCert;
+  key: DevKey;
+  thumbprint: string;
+}
+
+/**
+ * Result of classifying a single dev-cert candidate.
+ *
+ * - `usable`: cert + key fully loadable and `isValidDevCert` passes; safe to
+ *   pass into selection.
+ * - `skipped`: would-be-valid candidate that we can't actually use (missing
+ *   private key, parse failure, key not exportable from a system keychain,
+ *   orphaned cache file, etc.). A diagnostic warning has already been logged
+ *   at classification time; selection MUST exclude these.
+ * - `null` return (not a kind): the input isn't a dev-cert candidate at all
+ *   (e.g. unrelated cert in a shared store, expired, CN ≠ localhost). Silent
+ *   — these aren't worth surfacing.
+ */
+export type ClassifiedCandidate =
+  | { kind: "usable"; cert: DevCert; key: DevKey; thumbprint: string }
+  | { kind: "skipped"; thumbprint: string | null; reason: string };
+
+/**
+ * Optional metadata describing a candidate when we don't (yet) have a parsed
+ * cert object — e.g. when PowerShell hands us a `skipped[]` entry derived
+ * from the Windows cert store, or when we're surfacing a keychain-only
+ * entry on macOS.
+ */
+export interface CandidateMetadata {
+  thumbprint?: string | null;
+  subjectCN?: string | null;
+  version?: number | null;
+  notBefore?: Date | null;
+  notAfter?: Date | null;
+}
+
+/**
+ * Inputs to `classifyCandidate`. Exactly one of `loaded` / `forcedSkip` /
+ * `parseFailure` must be set; `source` is the human-readable provenance
+ * (file path, store path, "macOS login keychain") that appears in the
+ * warning log.
+ */
+export type CandidateInput =
+  | {
+      kind: "loaded";
+      source: string;
+      loaded: { cert: DevCert; key: DevKey | null; thumbprint: string };
+    }
+  | {
+      kind: "parseFailure";
+      source: string;
+      thumbprintHint?: string | null;
+    }
+  | {
+      kind: "forcedSkip";
+      source: string;
+      reason: string;
+      metadata?: CandidateMetadata;
+    };
+
+/**
+ * Classify a single candidate into `usable` / `skipped`, or return `null`
+ * for an input that isn't dev-cert-shaped (silent, not logged).
+ *
+ * Side effect: when the return is `kind: "skipped"`, a single human-readable
+ * `log()` line is emitted at classification time so the warning surfaces
+ * BEFORE any selection happens.
+ */
+export function classifyCandidate(
+  input: CandidateInput
+): ClassifiedCandidate | null {
+  if (input.kind === "loaded") {
+    const { cert, key, thumbprint } = input.loaded;
+    const certPassesValidity = isValidDevCert(cert);
+
+    if (!certPassesValidity) {
+      // Not a dev cert (CN ≠ localhost, expired, no OID extension, version <
+      // MIN). Silent — there's nothing the user can act on.
+      return null;
+    }
+
+    if (!key) {
+      const reason = "PFX contains certificate without matching private key";
+      logSkipReason(thumbprint, input.source, reason, {
+        subjectCN: cert.subjectCN,
+        version: getCertificateVersion(cert),
+        notBefore: cert.notBefore,
+        notAfter: cert.notAfter,
+      });
+      return { kind: "skipped", thumbprint, reason };
+    }
+
+    return { kind: "usable", cert, key, thumbprint };
+  }
+
+  if (input.kind === "parseFailure") {
+    // We only warn on parse failures for files whose name matches the
+    // canonical aspnetcore-localhost-<thumb>.pfx pattern (the caller passes
+    // the extracted hint). Generic .pfx files in a shared directory aren't
+    // ours to worry about.
+    if (!input.thumbprintHint) return null;
+    const reason = "failed to parse PFX (corrupt or wrong password)";
+    logSkipReason(input.thumbprintHint, input.source, reason, {});
+    return { kind: "skipped", thumbprint: input.thumbprintHint, reason };
+  }
+
+  // forcedSkip
+  logSkipReason(
+    input.metadata?.thumbprint ?? null,
+    input.source,
+    input.reason,
+    input.metadata ?? {}
+  );
+  return {
+    kind: "skipped",
+    thumbprint: input.metadata?.thumbprint ?? null,
+    reason: input.reason,
+  };
+}
+
+/**
+ * Choose the best dev cert among a set of pre-classified usable candidates.
+ * Sort key: highest version byte first, then latest `notAfter` as the
+ * tiebreaker — mirrors .NET's `dotnet dev-certs` resolution behaviour.
+ *
+ * When more than one usable candidate is present, emits a single
+ * multi-candidate selection warning so the user can see exactly which
+ * thumbprints were considered. The warning is NOT emitted for unusable
+ * candidates — those get their own warning at classification time.
+ */
+export function selectBestDevCert(
+  usable: UsableDevCert[],
+  context: string
+): UsableDevCert | null {
+  if (usable.length === 0) return null;
+
+  const sorted = [...usable].sort((a, b) => {
+    const versionA = getCertificateVersion(a.cert);
+    const versionB = getCertificateVersion(b.cert);
+    if (versionA !== versionB) return versionB - versionA;
+    return b.cert.notAfter.getTime() - a.cert.notAfter.getTime();
+  });
+
+  const selected = sorted[0];
+
+  if (sorted.length > 1) {
+    const lines = [
+      `Multiple valid ASP.NET dev certs found in ${context}; selected ${selected.thumbprint}.`,
+      `  Candidates:`,
+      ...sorted.map((c, i) => {
+        const tag = i === 0 ? "[selected]" : "[skipped] ";
+        return `    ${tag} thumbprint=${c.thumbprint} version=${getCertificateVersion(c.cert)} notBefore=${c.cert.notBefore.toISOString()} notAfter=${c.cert.notAfter.toISOString()}`;
+      }),
+    ];
+    log(lines.join("\n"));
+  }
+
+  return selected;
+}
+
+function logSkipReason(
+  thumbprint: string | null,
+  source: string,
+  reason: string,
+  meta: CandidateMetadata
+): void {
+  const subjectCN = meta.subjectCN ?? "(unknown)";
+  const version =
+    meta.version === undefined || meta.version === null
+      ? "(unknown)"
+      : String(meta.version);
+  const notBefore = meta.notBefore
+    ? meta.notBefore.toISOString()
+    : "(unknown)";
+  const notAfter = meta.notAfter ? meta.notAfter.toISOString() : "(unknown)";
+  log(
+    `Skipping ASP.NET dev cert ${thumbprint ?? "(unknown)"} (${source}): ${reason}.\n` +
+      `  subjectCN=${subjectCN} version=${version} notBefore=${notBefore} notAfter=${notAfter}`
+  );
+}
+
+/**
+ * Extract the canonical SHA-1 thumbprint embedded in a PFX filename that
+ * follows the `aspnetcore-localhost-<thumb>.pfx` or `<thumb>.pfx` patterns.
+ * Returns null when the filename doesn't match — caller treats parse
+ * failures on non-canonical names as silent (they aren't ours).
+ */
+export function extractThumbprintHintFromFilename(
+  filename: string
+): string | null {
+  const base = path.basename(filename, ".pfx");
+  const aspnetMatch = base.match(/^aspnetcore-localhost-([0-9A-Fa-f]{40})$/);
+  if (aspnetMatch) return aspnetMatch[1].toUpperCase();
+  const bareMatch = base.match(/^([0-9A-Fa-f]{40})$/);
+  if (bareMatch) return bareMatch[1].toUpperCase();
+  return null;
+}
 
 /**
  * Base implementation for platform certificate stores.
@@ -42,11 +246,7 @@ export abstract class BaseCertificateStore implements PlatformCertificateStore {
     };
   }
 
-  abstract findExistingDevCert(): Promise<{
-    cert: DevCert;
-    key: DevKey;
-    thumbprint: string;
-  } | null>;
+  abstract findExistingDevCert(): Promise<UsableDevCert | null>;
 
   abstract saveCertificate(
     cert: DevCert,
@@ -71,22 +271,36 @@ export abstract class BaseCertificateStore implements PlatformCertificateStore {
 
   /**
    * Parse a PFX file and extract the certificate, private key, and thumbprint.
+   * Returns `{ cert, key }` where `key` may be null when the PFX is cert-only.
+   * Returns null only on outright parse failure (corrupt bytes, wrong
+   * password, unsupported PBE).
+   */
+  protected async loadPfxLenient(
+    pfxPath: string,
+    password: string = ""
+  ): Promise<{ cert: DevCert; key: DevKey | null; thumbprint: string } | null> {
+    try {
+      const pfxBytes = fs.readFileSync(pfxPath);
+      const { cert, key } = await parsePfx(pfxBytes, password);
+      return { cert, key: key ?? null, thumbprint: cert.thumbprintSha1 };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Parse a PFX file and extract the certificate, private key, and thumbprint.
    * Returns null if the file cannot be parsed or is missing cert/key bags.
+   * Strict variant — used by existing call sites that want a usable identity
+   * or nothing.
    */
   protected async loadPfx(
     pfxPath: string,
     password: string = ""
-  ): Promise<{ cert: DevCert; key: DevKey; thumbprint: string } | null> {
-    try {
-      const pfxBytes = fs.readFileSync(pfxPath);
-      const { cert, key } = await parsePfx(pfxBytes, password);
-      if (!key) return null;
-      // .NET X509Store keys files by SHA-1, so the thumbprint we hand
-      // back here (which becomes the {thumbprint}.pfx filename) is SHA-1.
-      return { cert, key, thumbprint: cert.thumbprintSha1 };
-    } catch {
-      return null;
-    }
+  ): Promise<UsableDevCert | null> {
+    const loaded = await this.loadPfxLenient(pfxPath, password);
+    if (!loaded || !loaded.key) return null;
+    return { cert: loaded.cert, key: loaded.key, thumbprint: loaded.thumbprint };
   }
 
   /**
@@ -105,34 +319,78 @@ export abstract class BaseCertificateStore implements PlatformCertificateStore {
   }
 
   /**
-   * Scan a directory for PFX files containing valid dev certs.
-   * Returns the one with the highest version, or null if none found.
+   * Scan a directory for PFX files matching `aspnetcore-localhost-<thumb>.pfx`
+   * or `<thumb>.pfx` (the two canonical dev-cert filename shapes used by
+   * .NET on macOS/Linux). For each match:
+   *
+   * 1. Try to parse it. Parse failures on canonically-named files emit the
+   *    "failed to parse PFX" unusable warning.
+   * 2. If parsed and the cert passes `isValidDevCert` but there's no private
+   *    key, emit the "no matching private key" unusable warning.
+   * 3. Otherwise classify as `usable`.
+   *
+   * Selection runs only over the surviving usable candidates via
+   * `selectBestDevCert`. Multi-candidate selection emits its own warning.
+   *
+   * Callers may pre-filter via `filenamePredicate` (defaults to "accept any
+   * *.pfx whose basename matches a canonical dev-cert thumbprint pattern").
    */
   protected async findBestDevCertInDir(
     dir: string,
-    password: string = ""
-  ): Promise<{ cert: DevCert; key: DevKey; thumbprint: string } | null> {
+    password: string = "",
+    options: {
+      filenamePredicate?: (filename: string) => boolean;
+      context?: string;
+      extraSkipped?: ClassifiedCandidate[];
+    } = {}
+  ): Promise<UsableDevCert | null> {
     if (!fs.existsSync(dir)) return null;
 
-    let best: { cert: DevCert; key: DevKey; thumbprint: string } | null = null;
-    let bestVersion = -1;
+    const context = options.context ?? dir;
+    const usable: UsableDevCert[] = [];
 
-    const files = fs.readdirSync(dir).filter((f) => f.endsWith(".pfx"));
+    const files = fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith(".pfx"))
+      .filter((f) =>
+        options.filenamePredicate ? options.filenamePredicate(f) : true
+      );
+
     for (const file of files) {
-      try {
-        const result = await this.loadPfx(`${dir}/${file}`, password);
-        if (!result || !isValidDevCert(result.cert)) continue;
+      const filePath = path.join(dir, file);
+      const thumbprintHint = extractThumbprintHintFromFilename(file);
+      const loaded = await this.loadPfxLenient(filePath, password);
 
-        const version = getCertificateVersion(result.cert);
-        if (version > bestVersion) {
-          best = result;
-          bestVersion = version;
-        }
-      } catch {
-        // Skip invalid PFX files
+      if (!loaded) {
+        // Canonical name + parse failure → warn; otherwise silent.
+        classifyCandidate({
+          kind: "parseFailure",
+          source: filePath,
+          thumbprintHint,
+        });
+        continue;
       }
+
+      const classified = classifyCandidate({
+        kind: "loaded",
+        source: filePath,
+        loaded,
+      });
+
+      if (classified === null) continue;
+      if (classified.kind === "usable") {
+        usable.push(classified);
+      }
+      // skipped → already logged inside classifyCandidate
     }
 
-    return best;
+    // Allow callers to mix in additional skipped entries discovered outside
+    // the folder scan (e.g. keychain-only thumbprints on macOS). They've
+    // already been logged at classification time; we accept them here only
+    // so the function signature documents that selection sees nothing but
+    // usable candidates.
+    void options.extraSkipped;
+
+    return selectBestDevCert(usable, context);
   }
 }

--- a/src/vscode-ui-extension/src/platform/baseStore.ts
+++ b/src/vscode-ui-extension/src/platform/baseStore.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import * as vscode from "vscode";
 import { type PlatformCertificateStore, type CertificateStatus } from "./types";
 import { isValidDevCert, getCertificateVersion } from "../cert/generator";
 import { type DevCert, type DevKey } from "../cert/types";
@@ -92,7 +93,9 @@ export function classifyCandidate(
     }
 
     if (!key) {
-      const reason = "PFX contains certificate without matching private key";
+      const reason = vscode.l10n.t(
+        "PFX contains certificate without matching private key"
+      );
       logSkipReason(thumbprint, input.source, reason, {
         subjectCN: cert.subjectCN,
         version: getCertificateVersion(cert),
@@ -111,12 +114,15 @@ export function classifyCandidate(
     // the extracted hint). Generic .pfx files in a shared directory aren't
     // ours to worry about.
     if (!input.thumbprintHint) return null;
-    const reason = "failed to parse PFX (corrupt or wrong password)";
+    const reason = vscode.l10n.t(
+      "failed to parse PFX (corrupt or wrong password)"
+    );
     logSkipReason(input.thumbprintHint, input.source, reason, {});
     return { kind: "skipped", thumbprint: input.thumbprintHint, reason };
   }
 
-  // forcedSkip
+  // forcedSkip — the reason has already been localized by the caller (the
+  // platform-specific store) since the wording is platform-specific.
   logSkipReason(
     input.metadata?.thumbprint ?? null,
     input.source,
@@ -156,13 +162,27 @@ export function selectBestDevCert(
   const selected = sorted[0];
 
   if (sorted.length > 1) {
+    const header = vscode.l10n.t(
+      "Multiple valid ASP.NET dev certs found in {0}; selected {1}.",
+      context,
+      selected.thumbprint
+    );
+    const candidatesHeader = vscode.l10n.t("  Candidates:");
+    const selectedTag = vscode.l10n.t("[selected]");
+    const skippedTag = vscode.l10n.t("[skipped] ");
     const lines = [
-      `Multiple valid ASP.NET dev certs found in ${context}; selected ${selected.thumbprint}.`,
-      `  Candidates:`,
-      ...sorted.map((c, i) => {
-        const tag = i === 0 ? "[selected]" : "[skipped] ";
-        return `    ${tag} thumbprint=${c.thumbprint} version=${getCertificateVersion(c.cert)} notBefore=${c.cert.notBefore.toISOString()} notAfter=${c.cert.notAfter.toISOString()}`;
-      }),
+      header,
+      candidatesHeader,
+      ...sorted.map((c, i) =>
+        vscode.l10n.t(
+          "    {0} thumbprint={1} version={2} notBefore={3} notAfter={4}",
+          i === 0 ? selectedTag : skippedTag,
+          c.thumbprint,
+          getCertificateVersion(c.cert),
+          c.cert.notBefore.toISOString(),
+          c.cert.notAfter.toISOString()
+        )
+      ),
     ];
     log(lines.join("\n"));
   }
@@ -176,18 +196,25 @@ function logSkipReason(
   reason: string,
   meta: CandidateMetadata
 ): void {
-  const subjectCN = meta.subjectCN ?? "(unknown)";
+  const unknown = vscode.l10n.t("(unknown)");
+  const subjectCN = meta.subjectCN ?? unknown;
   const version =
     meta.version === undefined || meta.version === null
-      ? "(unknown)"
+      ? unknown
       : String(meta.version);
-  const notBefore = meta.notBefore
-    ? meta.notBefore.toISOString()
-    : "(unknown)";
-  const notAfter = meta.notAfter ? meta.notAfter.toISOString() : "(unknown)";
+  const notBefore = meta.notBefore ? meta.notBefore.toISOString() : unknown;
+  const notAfter = meta.notAfter ? meta.notAfter.toISOString() : unknown;
   log(
-    `Skipping ASP.NET dev cert ${thumbprint ?? "(unknown)"} (${source}): ${reason}.\n` +
-      `  subjectCN=${subjectCN} version=${version} notBefore=${notBefore} notAfter=${notAfter}`
+    vscode.l10n.t(
+      "Skipping ASP.NET dev cert {0} ({1}): {2}.\n  subjectCN={3} version={4} notBefore={5} notAfter={6}",
+      thumbprint ?? unknown,
+      source,
+      reason,
+      subjectCN,
+      version,
+      notBefore,
+      notAfter
+    )
   );
 }
 

--- a/src/vscode-ui-extension/src/platform/baseStore.ts
+++ b/src/vscode-ui-extension/src/platform/baseStore.ts
@@ -319,12 +319,13 @@ export abstract class BaseCertificateStore implements PlatformCertificateStore {
   }
 
   /**
-   * Scan a directory for PFX files matching `aspnetcore-localhost-<thumb>.pfx`
-   * or `<thumb>.pfx` (the two canonical dev-cert filename shapes used by
-   * .NET on macOS/Linux). For each match:
+   * Scan a directory for `*.pfx` files and classify each one. For every
+   * match:
    *
-   * 1. Try to parse it. Parse failures on canonically-named files emit the
-   *    "failed to parse PFX" unusable warning.
+   * 1. Try to parse it. Parse failures on canonically-named files
+   *    (`aspnetcore-localhost-<thumb>.pfx` or `<thumb>.pfx`) emit the
+   *    "failed to parse PFX" unusable warning; parse failures on other
+   *    filenames are silent — they may belong to other tools.
    * 2. If parsed and the cert passes `isValidDevCert` but there's no private
    *    key, emit the "no matching private key" unusable warning.
    * 3. Otherwise classify as `usable`.
@@ -332,8 +333,10 @@ export abstract class BaseCertificateStore implements PlatformCertificateStore {
    * Selection runs only over the surviving usable candidates via
    * `selectBestDevCert`. Multi-candidate selection emits its own warning.
    *
-   * Callers may pre-filter via `filenamePredicate` (defaults to "accept any
-   * *.pfx whose basename matches a canonical dev-cert thumbprint pattern").
+   * Callers may narrow which files to consider via `filenamePredicate`
+   * (default: accept every `*.pfx`). Whether a parse failure produces a
+   * warning is controlled separately by `extractThumbprintHintFromFilename`
+   * — see step 1.
    */
   protected async findBestDevCertInDir(
     dir: string,

--- a/src/vscode-ui-extension/src/platform/baseStore.ts
+++ b/src/vscode-ui-extension/src/platform/baseStore.ts
@@ -344,7 +344,6 @@ export abstract class BaseCertificateStore implements PlatformCertificateStore {
     options: {
       filenamePredicate?: (filename: string) => boolean;
       context?: string;
-      extraSkipped?: ClassifiedCandidate[];
     } = {}
   ): Promise<UsableDevCert | null> {
     if (!fs.existsSync(dir)) return null;
@@ -386,13 +385,6 @@ export abstract class BaseCertificateStore implements PlatformCertificateStore {
       }
       // skipped → already logged inside classifyCandidate
     }
-
-    // Allow callers to mix in additional skipped entries discovered outside
-    // the folder scan (e.g. keychain-only thumbprints on macOS). They've
-    // already been logged at classification time; we accept them here only
-    // so the function signature documents that selection sees nothing but
-    // usable candidates.
-    void options.extraSkipped;
 
     return selectBestDevCert(usable, context);
   }

--- a/src/vscode-ui-extension/src/platform/macStore.ts
+++ b/src/vscode-ui-extension/src/platform/macStore.ts
@@ -2,12 +2,20 @@ import { randomUUID } from "crypto";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { BaseCertificateStore } from "./baseStore";
+import {
+  BaseCertificateStore,
+  classifyCandidate,
+  selectBestDevCert,
+  type UsableDevCert,
+} from "./baseStore";
 import { runProcess } from "./processUtil";
-import { isValidDevCert } from "../cert/generator";
+import {
+  getCertificateVersion,
+  isValidDevCert,
+} from "../cert/generator";
 import { certToDer } from "../cert/exporter";
 import { ASPNET_HTTPS_OID } from "../cert/properties";
-import { type DevCert, type DevKey } from "../cert/types";
+import { DevCert, type DevKey } from "../cert/types";
 
 /**
  * macOS certificate store implementation.
@@ -27,32 +35,146 @@ export class MacCertificateStore extends BaseCertificateStore {
     return path.join(os.homedir(), "Library", "Keychains", "login.keychain-db");
   }
 
-  async findExistingDevCert(): Promise<{
-    cert: DevCert;
-    key: DevKey;
-    thumbprint: string;
-  } | null> {
-    if (!fs.existsSync(this.devCertsDir)) return null;
+  async findExistingDevCert(): Promise<UsableDevCert | null> {
+    const context = "macOS login keychain";
+    const usable: UsableDevCert[] = [];
+    const seenThumbprints = new Set<string>();
 
-    const pfxFiles = fs
-      .readdirSync(this.devCertsDir)
-      .filter(
-        (f) => f.startsWith("aspnetcore-localhost-") && f.endsWith(".pfx")
-      );
+    // 1) Walk ~/.aspnet/dev-certs/https/. For each parseable PFX whose cert
+    //    passes isValidDevCert, additionally verify a matching cert is
+    //    actually present in the login keychain via `security find-
+    //    certificate -Z <thumb>` (public-only, no prompt). PFXs whose cert
+    //    isn't in the keychain are classified as "orphaned cache file"
+    //    skipped entries and excluded from selection.
+    if (fs.existsSync(this.devCertsDir)) {
+      const pfxFiles = fs
+        .readdirSync(this.devCertsDir)
+        .filter(
+          (f) => f.startsWith("aspnetcore-localhost-") && f.endsWith(".pfx")
+        );
 
-    for (const pfxFile of pfxFiles) {
-      try {
+      for (const pfxFile of pfxFiles) {
         const pfxPath = path.join(this.devCertsDir, pfxFile);
-        const result = await this.loadPfx(pfxPath);
-        if (result && isValidDevCert(result.cert)) {
-          return result;
+        const loaded = await this.loadPfxLenient(pfxPath);
+
+        if (!loaded) {
+          classifyCandidate({
+            kind: "parseFailure",
+            source: pfxPath,
+            thumbprintHint: extractThumbHintFromMacFilename(pfxFile),
+          });
+          continue;
         }
-      } catch {
-        // Skip invalid PFX files
+
+        const classified = classifyCandidate({
+          kind: "loaded",
+          source: pfxPath,
+          loaded,
+        });
+        if (classified === null) continue;
+        if (classified.kind !== "usable") {
+          seenThumbprints.add(loaded.thumbprint);
+          continue;
+        }
+
+        // Verify keychain presence — no prompt, public-only.
+        const inKeychain = await this.isCertInKeychain(classified.thumbprint);
+        if (!inKeychain) {
+          classifyCandidate({
+            kind: "forcedSkip",
+            source: pfxPath,
+            reason:
+              "PFX present on disk but matching certificate not in macOS login keychain (orphaned cache file)",
+            metadata: {
+              thumbprint: classified.thumbprint,
+              subjectCN: classified.cert.subjectCN,
+              version: getCertificateVersion(classified.cert),
+              notBefore: classified.cert.notBefore,
+              notAfter: classified.cert.notAfter,
+            },
+          });
+          seenThumbprints.add(classified.thumbprint);
+          continue;
+        }
+
+        seenThumbprints.add(classified.thumbprint);
+        usable.push(classified);
       }
     }
 
-    return null;
+    // 2) Soft keychain enumeration — emit a warning for keychain-resident
+    //    dev certs that lack a matching cache PFX. Public-only read, never
+    //    triggers an ACL prompt, low EDR signal.
+    const keychainEntries = await this.enumerateKeychainDevCerts();
+    for (const entry of keychainEntries) {
+      if (seenThumbprints.has(entry.thumbprint)) continue;
+      classifyCandidate({
+        kind: "forcedSkip",
+        source: context,
+        reason:
+          `present in keychain but no matching PFX in ${this.devCertsDir}/aspnetcore-localhost-${entry.thumbprint}.pfx`,
+        metadata: {
+          thumbprint: entry.thumbprint,
+          subjectCN: entry.cert.subjectCN,
+          version: getCertificateVersion(entry.cert),
+          notBefore: entry.cert.notBefore,
+          notAfter: entry.cert.notAfter,
+        },
+      });
+    }
+
+    return selectBestDevCert(usable, this.devCertsDir);
+  }
+
+  /**
+   * Returns true if a certificate with the given SHA-1 thumbprint is
+   * present in the login keychain. Uses `security find-certificate -Z`
+   * which only reads the public certificate — no ACL prompt is raised
+   * regardless of the cert's private-key ACL.
+   */
+  private async isCertInKeychain(thumbprint: string): Promise<boolean> {
+    const result = await runProcess("security", [
+      "find-certificate",
+      "-Z",
+      thumbprint,
+      this.keychainPath,
+    ]);
+    return result.exitCode === 0;
+  }
+
+  /**
+   * Enumerate ASP.NET dev cert candidates that exist in the login keychain.
+   * Returns parsed certs whose CN is `localhost`, that bear the ASP.NET
+   * custom OID, and whose validity window is current. Public-only, no
+   * prompts.
+   */
+  private async enumerateKeychainDevCerts(): Promise<
+    Array<{ cert: DevCert; thumbprint: string }>
+  > {
+    const result = await runProcess("security", [
+      "find-certificate",
+      "-a",
+      "-p",
+      "-Z",
+      this.keychainPath,
+    ]);
+    if (result.exitCode !== 0) return [];
+
+    const out: Array<{ cert: DevCert; thumbprint: string }> = [];
+    const pemBlocks = extractPemBlocks(result.stdout);
+    for (const pem of pemBlocks) {
+      try {
+        const cert = new DevCert(pem);
+        if (cert.subjectCN !== "localhost") continue;
+        if (!cert.hasExtension(ASPNET_HTTPS_OID)) continue;
+        if (!isValidDevCert(cert)) continue;
+        out.push({ cert, thumbprint: cert.thumbprintSha1 });
+      } catch {
+        // Skip lines that don't parse as a cert (the -a -p -Z output
+        // includes SHA-1 lines interleaved with PEM blocks).
+      }
+    }
+    return out;
   }
 
   async saveCertificate(
@@ -184,4 +306,24 @@ export class MacCertificateStore extends BaseCertificateStore {
       }
     }
   }
+}
+
+function extractThumbHintFromMacFilename(filename: string): string | null {
+  const m = filename.match(/^aspnetcore-localhost-([0-9A-Fa-f]{40})\.pfx$/);
+  return m ? m[1].toUpperCase() : null;
+}
+
+/**
+ * Pull PEM-encoded CERTIFICATE blocks out of `security find-certificate -p`
+ * output. The CLI interleaves SHA-1 hash lines (when `-Z` is passed) with
+ * the PEM blocks; we just grab the blocks.
+ */
+function extractPemBlocks(text: string): string[] {
+  const blocks: string[] = [];
+  const regex = /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g;
+  let m: RegExpExecArray | null;
+  while ((m = regex.exec(text)) !== null) {
+    blocks.push(m[0]);
+  }
+  return blocks;
 }

--- a/src/vscode-ui-extension/src/platform/macStore.ts
+++ b/src/vscode-ui-extension/src/platform/macStore.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import * as vscode from "vscode";
 import {
   BaseCertificateStore,
   classifyCandidate,
@@ -84,8 +85,9 @@ export class MacCertificateStore extends BaseCertificateStore {
           classifyCandidate({
             kind: "forcedSkip",
             source: pfxPath,
-            reason:
-              "PFX present on disk but matching certificate not in macOS login keychain (orphaned cache file)",
+            reason: vscode.l10n.t(
+              "PFX present on disk but matching certificate not in macOS login keychain (orphaned cache file)"
+            ),
             metadata: {
               thumbprint: classified.thumbprint,
               subjectCN: classified.cert.subjectCN,
@@ -112,8 +114,10 @@ export class MacCertificateStore extends BaseCertificateStore {
       classifyCandidate({
         kind: "forcedSkip",
         source: context,
-        reason:
-          `present in keychain but no matching PFX in ${this.devCertsDir}/aspnetcore-localhost-${entry.thumbprint}.pfx`,
+        reason: vscode.l10n.t(
+          "present in keychain but no matching PFX in {0}",
+          `${this.devCertsDir}/aspnetcore-localhost-${entry.thumbprint}.pfx`
+        ),
         metadata: {
           thumbprint: entry.thumbprint,
           subjectCN: entry.cert.subjectCN,

--- a/src/vscode-ui-extension/src/platform/macStore.ts
+++ b/src/vscode-ui-extension/src/platform/macStore.ts
@@ -5,6 +5,7 @@ import * as path from "path";
 import {
   BaseCertificateStore,
   classifyCandidate,
+  extractThumbprintHintFromFilename,
   selectBestDevCert,
   type UsableDevCert,
 } from "./baseStore";
@@ -61,7 +62,7 @@ export class MacCertificateStore extends BaseCertificateStore {
           classifyCandidate({
             kind: "parseFailure",
             source: pfxPath,
-            thumbprintHint: extractThumbHintFromMacFilename(pfxFile),
+            thumbprintHint: extractThumbprintHintFromFilename(pfxFile),
           });
           continue;
         }
@@ -306,11 +307,6 @@ export class MacCertificateStore extends BaseCertificateStore {
       }
     }
   }
-}
-
-function extractThumbHintFromMacFilename(filename: string): string | null {
-  const m = filename.match(/^aspnetcore-localhost-([0-9A-Fa-f]{40})\.pfx$/);
-  return m ? m[1].toUpperCase() : null;
 }
 
 /**

--- a/src/vscode-ui-extension/src/platform/windowsStore.ts
+++ b/src/vscode-ui-extension/src/platform/windowsStore.ts
@@ -78,22 +78,34 @@ export class WindowsCertificateStore extends BaseCertificateStore {
     // Enumerate every dev-cert candidate in the configured My store, then
     // attempt to export each as a PBES2/AES PFX. We hand selection back to
     // shared TS so the version-byte tiebreaker logic stays in one place.
+    //
+    // The script stays inside the PS cert-provider surface and built-in
+    // cmdlets — no `New-Object System.*`, no explicit [System.X.Y.Z] type
+    // references, no .NET-specific property paths (e.g. CNG-only
+    // PrivateKey.Key.ExportPolicy). Properties accessed on the
+    // X509Certificate2 objects yielded by `Cert:\…` are the same surface
+    // the rest of the codebase already relies on (Thumbprint, Subject,
+    // NotBefore/NotAfter, HasPrivateKey, Extensions).
     const script = `
       $ErrorActionPreference = 'Stop'
       $oid = '${ASPNET_HTTPS_OID}'
-      $candidates = New-Object System.Collections.ArrayList
-      $skipped = New-Object System.Collections.ArrayList
+      $candidates = @()
+      $skipped = @()
       $certs = Get-ChildItem Cert:\\${this.storeLocation}\\My | Where-Object {
         $_.Extensions | Where-Object { $_.Oid.Value -eq $oid }
       }
       foreach ($cert in $certs) {
         $thumb = $cert.Thumbprint
+        # Subject is a comma-separated RDN string ("CN=localhost, O=..."). Pull
+        # the first CN out via regex instead of GetNameInfo, which would need
+        # an explicit [System.Security.Cryptography.X509Certificates.X509NameType]
+        # type reference.
         $cn = $null
-        try { $cn = $cert.GetNameInfo([System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName, $false) } catch {}
+        if ($cert.Subject -match 'CN=([^,]+)') { $cn = $matches[1].Trim() }
         $nbf = $cert.NotBefore.ToUniversalTime().ToString('o')
         $exp = $cert.NotAfter.ToUniversalTime().ToString('o')
         if (-not $cert.HasPrivateKey) {
-          [void]$skipped.Add(@{ thumbprint = $thumb; subjectCN = $cn; notBefore = $nbf; notAfter = $exp; reason = 'no private key in store' })
+          $skipped += @{ thumbprint = $thumb; subjectCN = $cn; notBefore = $nbf; notAfter = $exp; reason = 'no private key in store' }
           continue
         }
         try {
@@ -103,24 +115,20 @@ export class WindowsCertificateStore extends BaseCertificateStore {
           # produces a legacy PKCS#12 PBE format that our pkijs-based parser
           # deliberately rejects (see cert/pfx.ts).
           Export-PfxCertificate -Cert $cert -FilePath $tmpPfx -Password $pwd -CryptoAlgorithmOption AES256_SHA256 | Out-Null
-          [void]$candidates.Add(@{ thumbprint = $thumb; pfxPath = $tmpPfx; subjectCN = $cn; notBefore = $nbf; notAfter = $exp })
+          $candidates += @{ thumbprint = $thumb; pfxPath = $tmpPfx; subjectCN = $cn; notBefore = $nbf; notAfter = $exp }
         } catch {
+          # No CNG / RSA-specific introspection here — that would mean
+          # touching .NET types beyond what the cert provider already
+          # surfaces. Message-string matching is intentionally coarse;
+          # the TS-side warning still names the underlying error when
+          # we can't classify it.
           $msg = $_.Exception.Message
-          # $cert.PrivateKey.Key.ExportPolicy resolves only for RSA/CNG-backed
-          # keys. Legacy CAPI keys and non-RSA algorithms surface the policy
-          # at a different path (or not at all) — we treat the lookup as
-          # best-effort and fall back to message-string matching when it
-          # throws or returns null.
-          $policy = $null
-          try { $policy = $cert.PrivateKey.Key.ExportPolicy } catch {}
-          if ($policy) {
-            $reason = "private key not exportable (KeyExportPolicy=$policy)"
-          } elseif ($msg -match 'not exportable' -or $msg -match 'cannot be exported') {
+          if ($msg -match 'not exportable' -or $msg -match 'cannot be exported') {
             $reason = 'private key not exportable'
           } else {
             $reason = "Export-PfxCertificate failed: $msg"
           }
-          [void]$skipped.Add(@{ thumbprint = $thumb; subjectCN = $cn; notBefore = $nbf; notAfter = $exp; reason = $reason })
+          $skipped += @{ thumbprint = $thumb; subjectCN = $cn; notBefore = $nbf; notAfter = $exp; reason = $reason }
         }
       }
       $payload = @{ candidates = $candidates; skipped = $skipped }

--- a/src/vscode-ui-extension/src/platform/windowsStore.ts
+++ b/src/vscode-ui-extension/src/platform/windowsStore.ts
@@ -362,8 +362,12 @@ function metadataLooksLikeValidDevCert(sk: PsSkipped): boolean {
   // for clearly-unrelated certs (e.g. expired or differently-named) that
   // happened to carry the same OID. We can't check the version byte from
   // TS without parsing the cert, so we skip that gate here.
-  if (!sk.subjectCN) return false;
-  if (sk.subjectCN.toLowerCase() !== "localhost") return false;
+  //
+  // CN comparison is intentionally exact-match to mirror isValidDevCert
+  // (see cert/generator.ts:isValidDevCert) — staying loose here while the
+  // canonical gate is strict would just produce warnings for certs we'd
+  // never accept downstream anyway.
+  if (sk.subjectCN !== "localhost") return false;
   const nbf = parseDateOrNull(sk.notBefore);
   const exp = parseDateOrNull(sk.notAfter);
   if (!nbf || !exp) return false;

--- a/src/vscode-ui-extension/src/platform/windowsStore.ts
+++ b/src/vscode-ui-extension/src/platform/windowsStore.ts
@@ -106,6 +106,11 @@ export class WindowsCertificateStore extends BaseCertificateStore {
           [void]$candidates.Add(@{ thumbprint = $thumb; pfxPath = $tmpPfx; subjectCN = $cn; notBefore = $nbf; notAfter = $exp })
         } catch {
           $msg = $_.Exception.Message
+          # $cert.PrivateKey.Key.ExportPolicy resolves only for RSA/CNG-backed
+          # keys. Legacy CAPI keys and non-RSA algorithms surface the policy
+          # at a different path (or not at all) — we treat the lookup as
+          # best-effort and fall back to message-string matching when it
+          # throws or returns null.
           $policy = $null
           try { $policy = $cert.PrivateKey.Key.ExportPolicy } catch {}
           if ($policy) {

--- a/src/vscode-ui-extension/src/platform/windowsStore.ts
+++ b/src/vscode-ui-extension/src/platform/windowsStore.ts
@@ -2,9 +2,13 @@ import { randomUUID } from "crypto";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { BaseCertificateStore } from "./baseStore";
+import {
+  BaseCertificateStore,
+  classifyCandidate,
+  selectBestDevCert,
+  type UsableDevCert,
+} from "./baseStore";
 import { runProcess } from "./processUtil";
-import { isValidDevCert } from "../cert/generator";
 import { ASPNET_HTTPS_OID } from "../cert/properties";
 import { certToDer } from "../cert/exporter";
 import { type DevCert, type DevKey } from "../cert/types";
@@ -26,6 +30,27 @@ async function getPowerShell(): Promise<string> {
   return resolvedPwsh;
 }
 
+interface PsCandidate {
+  thumbprint: string;
+  pfxPath: string;
+  subjectCN: string | null;
+  notBefore: string;
+  notAfter: string;
+}
+
+interface PsSkipped {
+  thumbprint: string;
+  subjectCN: string | null;
+  notBefore: string;
+  notAfter: string;
+  reason: string;
+}
+
+interface PsEnumeration {
+  candidates: PsCandidate[];
+  skipped: PsSkipped[];
+}
+
 /**
  * Windows certificate store implementation.
  *
@@ -40,28 +65,52 @@ export class WindowsCertificateStore extends BaseCertificateStore {
     super();
   }
 
-  async findExistingDevCert(): Promise<{
-    cert: DevCert;
-    key: DevKey;
-    thumbprint: string;
-  } | null> {
-    // Use PowerShell to find dev certs in the configured My store and export
-    // the best one as PFX.
+  async findExistingDevCert(): Promise<UsableDevCert | null> {
+    // Enumerate every dev-cert candidate in the configured My store, then
+    // attempt to export each as a PBES2/AES PFX. We hand selection back to
+    // shared TS so the version-byte tiebreaker logic stays in one place.
     const script = `
       $ErrorActionPreference = 'Stop'
       $oid = '${ASPNET_HTTPS_OID}'
+      $candidates = New-Object System.Collections.ArrayList
+      $skipped = New-Object System.Collections.ArrayList
       $certs = Get-ChildItem Cert:\\${this.storeLocation}\\My | Where-Object {
         $_.Extensions | Where-Object { $_.Oid.Value -eq $oid }
-      } | Sort-Object NotAfter -Descending
-      if ($certs.Count -eq 0) { exit 1 }
-      $best = $certs[0]
-      $tmpPfx = Join-Path $env:TEMP ("devcert-" + [guid]::NewGuid().ToString("N") + ".pfx")
-      $pwd = ConvertTo-SecureString -String "export" -Force -AsPlainText
-      # AES256_SHA256 forces a PBES2/AES PFX. The default (TripleDES_SHA1)
-      # produces a legacy PKCS#12 PBE format that our pkijs-based parser
-      # deliberately rejects (see cert/pfx.ts).
-      Export-PfxCertificate -Cert $best -FilePath $tmpPfx -Password $pwd -CryptoAlgorithmOption AES256_SHA256 | Out-Null
-      Write-Output $tmpPfx
+      }
+      foreach ($cert in $certs) {
+        $thumb = $cert.Thumbprint
+        $cn = $null
+        try { $cn = $cert.GetNameInfo([System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName, $false) } catch {}
+        $nbf = $cert.NotBefore.ToUniversalTime().ToString('o')
+        $exp = $cert.NotAfter.ToUniversalTime().ToString('o')
+        if (-not $cert.HasPrivateKey) {
+          [void]$skipped.Add(@{ thumbprint = $thumb; subjectCN = $cn; notBefore = $nbf; notAfter = $exp; reason = 'no private key in store' })
+          continue
+        }
+        try {
+          $tmpPfx = Join-Path $env:TEMP ("devcert-" + [guid]::NewGuid().ToString("N") + ".pfx")
+          $pwd = ConvertTo-SecureString -String 'export' -Force -AsPlainText
+          # AES256_SHA256 forces a PBES2/AES PFX. The default (TripleDES_SHA1)
+          # produces a legacy PKCS#12 PBE format that our pkijs-based parser
+          # deliberately rejects (see cert/pfx.ts).
+          Export-PfxCertificate -Cert $cert -FilePath $tmpPfx -Password $pwd -CryptoAlgorithmOption AES256_SHA256 | Out-Null
+          [void]$candidates.Add(@{ thumbprint = $thumb; pfxPath = $tmpPfx; subjectCN = $cn; notBefore = $nbf; notAfter = $exp })
+        } catch {
+          $msg = $_.Exception.Message
+          $policy = $null
+          try { $policy = $cert.PrivateKey.Key.ExportPolicy } catch {}
+          if ($policy) {
+            $reason = "private key not exportable (KeyExportPolicy=$policy)"
+          } elseif ($msg -match 'not exportable' -or $msg -match 'cannot be exported') {
+            $reason = 'private key not exportable'
+          } else {
+            $reason = "Export-PfxCertificate failed: $msg"
+          }
+          [void]$skipped.Add(@{ thumbprint = $thumb; subjectCN = $cn; notBefore = $nbf; notAfter = $exp; reason = $reason })
+        }
+      }
+      $payload = @{ candidates = $candidates; skipped = $skipped }
+      $payload | ConvertTo-Json -Compress -Depth 4
     `;
 
     const pwsh = await getPowerShell();
@@ -74,16 +123,69 @@ export class WindowsCertificateStore extends BaseCertificateStore {
 
     if (result.exitCode !== 0) return null;
 
-    const pfxPath = result.stdout.trim();
+    const parsed = parseEnumeration(result.stdout);
+    if (!parsed) return null;
+
+    const tempPfxPaths: string[] = parsed.candidates.map((c) => c.pfxPath);
     try {
-      const loaded = await this.loadPfx(pfxPath, "export");
-      if (!loaded || !isValidDevCert(loaded.cert)) return null;
-      return loaded;
+      const usable: UsableDevCert[] = [];
+      const storeContext = `Windows ${this.storeLocation}\\My`;
+
+      for (const cand of parsed.candidates) {
+        const loaded = await this.loadPfxLenient(cand.pfxPath, "export");
+        if (!loaded) {
+          // PFX produced by Export-PfxCertificate failed to parse — surface
+          // as an unusable warning so the user has visibility.
+          classifyCandidate({
+            kind: "forcedSkip",
+            source: storeContext,
+            reason:
+              "Export-PfxCertificate produced a PFX that could not be parsed",
+            metadata: {
+              thumbprint: cand.thumbprint,
+              subjectCN: cand.subjectCN,
+              notBefore: parseDateOrNull(cand.notBefore),
+              notAfter: parseDateOrNull(cand.notAfter),
+            },
+          });
+          continue;
+        }
+
+        const classified = classifyCandidate({
+          kind: "loaded",
+          source: storeContext,
+          loaded,
+        });
+        if (classified === null) continue;
+        if (classified.kind === "usable") usable.push(classified);
+      }
+
+      for (const sk of parsed.skipped) {
+        // Re-apply isValidDevCert gates against the metadata we received so
+        // we don't emit the unusable warning for clearly-unrelated certs
+        // that happened to share the OID but are e.g. expired.
+        if (!metadataLooksLikeValidDevCert(sk)) continue;
+        classifyCandidate({
+          kind: "forcedSkip",
+          source: storeContext,
+          reason: sk.reason,
+          metadata: {
+            thumbprint: sk.thumbprint,
+            subjectCN: sk.subjectCN,
+            notBefore: parseDateOrNull(sk.notBefore),
+            notAfter: parseDateOrNull(sk.notAfter),
+          },
+        });
+      }
+
+      return selectBestDevCert(usable, storeContext);
     } finally {
-      try {
-        fs.unlinkSync(pfxPath);
-      } catch {
-        // best effort cleanup
+      for (const p of tempPfxPaths) {
+        try {
+          fs.unlinkSync(p);
+        } catch {
+          // best effort cleanup
+        }
       }
     }
   }
@@ -210,4 +312,53 @@ export class WindowsCertificateStore extends BaseCertificateStore {
 
     return result.stdout.trim() === "true";
   }
+}
+
+function parseEnumeration(stdout: string): PsEnumeration | null {
+  const trimmed = stdout.trim();
+  if (!trimmed) return { candidates: [], skipped: [] };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  // PowerShell's ConvertTo-Json emits a hashtable with a single child as a
+  // bare object rather than a 1-element array; coerce defensively.
+  if (!parsed || typeof parsed !== "object") return null;
+  const root = parsed as Record<string, unknown>;
+  return {
+    candidates: coerceArray<PsCandidate>(root.candidates),
+    skipped: coerceArray<PsSkipped>(root.skipped),
+  };
+}
+
+function coerceArray<T>(value: unknown): T[] {
+  if (value === undefined || value === null) return [];
+  if (Array.isArray(value)) return value as T[];
+  return [value as T];
+}
+
+function parseDateOrNull(s: string | null | undefined): Date | null {
+  if (!s) return null;
+  const d = new Date(s);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function metadataLooksLikeValidDevCert(sk: PsSkipped): boolean {
+  // The PS script already filtered by ASPNET_HTTPS_OID. We layer CN +
+  // validity-window checks on top so we don't emit the unusable warning
+  // for clearly-unrelated certs (e.g. expired or differently-named) that
+  // happened to carry the same OID. We can't check the version byte from
+  // TS without parsing the cert, so we skip that gate here.
+  if (!sk.subjectCN) return false;
+  if (sk.subjectCN.toLowerCase() !== "localhost") return false;
+  const nbf = parseDateOrNull(sk.notBefore);
+  const exp = parseDateOrNull(sk.notAfter);
+  if (!nbf || !exp) return false;
+  const now = new Date();
+  if (nbf > now || exp < now) return false;
+  return true;
 }

--- a/src/vscode-ui-extension/src/platform/windowsStore.ts
+++ b/src/vscode-ui-extension/src/platform/windowsStore.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import * as vscode from "vscode";
 import {
   BaseCertificateStore,
   classifyCandidate,
@@ -42,17 +43,29 @@ export interface PsCandidate {
   notAfter: string;
 }
 
+/** Classification of why the PS script couldn't export a cert. */
+export type PsSkipReason =
+  | "no-private-key"
+  | "not-exportable"
+  | "export-failed";
+
 /**
  * Shape of one entry in the PowerShell enumeration script's `skipped`
  * array — a cert that matched the dev-cert OID but couldn't be exported
  * (no private key, or key not exportable).
+ *
+ * `reasonDetail` carries the underlying exception message for the
+ * "export-failed" code (we can't classify it more precisely without
+ * reaching into .NET-specific types). TS-side maps the code to a
+ * localized human-readable reason; details get appended verbatim.
  */
 export interface PsSkipped {
   thumbprint: string;
   subjectCN: string | null;
   notBefore: string;
   notAfter: string;
-  reason: string;
+  reasonCode: PsSkipReason;
+  reasonDetail?: string;
 }
 
 export interface PsEnumeration {
@@ -105,7 +118,7 @@ export class WindowsCertificateStore extends BaseCertificateStore {
         $nbf = $cert.NotBefore.ToUniversalTime().ToString('o')
         $exp = $cert.NotAfter.ToUniversalTime().ToString('o')
         if (-not $cert.HasPrivateKey) {
-          $skipped += @{ thumbprint = $thumb; subjectCN = $cn; notBefore = $nbf; notAfter = $exp; reason = 'no private key in store' }
+          $skipped += @{ thumbprint = $thumb; subjectCN = $cn; notBefore = $nbf; notAfter = $exp; reasonCode = 'no-private-key' }
           continue
         }
         try {
@@ -119,16 +132,15 @@ export class WindowsCertificateStore extends BaseCertificateStore {
         } catch {
           # No CNG / RSA-specific introspection here — that would mean
           # touching .NET types beyond what the cert provider already
-          # surfaces. Message-string matching is intentionally coarse;
-          # the TS-side warning still names the underlying error when
-          # we can't classify it.
+          # surfaces. Coarse message-string matching distinguishes the
+          # "key locked" case from everything else; TS-side maps the code
+          # to a localized human-readable reason.
           $msg = $_.Exception.Message
           if ($msg -match 'not exportable' -or $msg -match 'cannot be exported') {
-            $reason = 'private key not exportable'
+            $skipped += @{ thumbprint = $thumb; subjectCN = $cn; notBefore = $nbf; notAfter = $exp; reasonCode = 'not-exportable' }
           } else {
-            $reason = "Export-PfxCertificate failed: $msg"
+            $skipped += @{ thumbprint = $thumb; subjectCN = $cn; notBefore = $nbf; notAfter = $exp; reasonCode = 'export-failed'; reasonDetail = $msg }
           }
-          $skipped += @{ thumbprint = $thumb; subjectCN = $cn; notBefore = $nbf; notAfter = $exp; reason = $reason }
         }
       }
       $payload = @{ candidates = $candidates; skipped = $skipped }
@@ -161,8 +173,9 @@ export class WindowsCertificateStore extends BaseCertificateStore {
           classifyCandidate({
             kind: "forcedSkip",
             source: storeContext,
-            reason:
-              "Export-PfxCertificate produced a PFX that could not be parsed",
+            reason: vscode.l10n.t(
+              "Export-PfxCertificate produced a PFX that could not be parsed"
+            ),
             metadata: {
               thumbprint: cand.thumbprint,
               subjectCN: cand.subjectCN,
@@ -190,7 +203,7 @@ export class WindowsCertificateStore extends BaseCertificateStore {
         classifyCandidate({
           kind: "forcedSkip",
           source: storeContext,
-          reason: sk.reason,
+          reason: localizeSkipReason(sk),
           metadata: {
             thumbprint: sk.thumbprint,
             subjectCN: sk.subjectCN,
@@ -367,6 +380,20 @@ function parseDateOrNull(s: string | null | undefined): Date | null {
   if (!s) return null;
   const d = new Date(s);
   return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function localizeSkipReason(sk: PsSkipped): string {
+  switch (sk.reasonCode) {
+    case "no-private-key":
+      return vscode.l10n.t("no private key in store");
+    case "not-exportable":
+      return vscode.l10n.t("private key not exportable");
+    case "export-failed":
+      return vscode.l10n.t(
+        "Export-PfxCertificate failed: {0}",
+        sk.reasonDetail ?? ""
+      );
+  }
 }
 
 function metadataLooksLikeValidDevCert(sk: PsSkipped): boolean {

--- a/src/vscode-ui-extension/src/platform/windowsStore.ts
+++ b/src/vscode-ui-extension/src/platform/windowsStore.ts
@@ -30,7 +30,11 @@ async function getPowerShell(): Promise<string> {
   return resolvedPwsh;
 }
 
-interface PsCandidate {
+/**
+ * Shape of one entry in the PowerShell enumeration script's `candidates`
+ * array — a cert whose private key was successfully exported as a PFX.
+ */
+export interface PsCandidate {
   thumbprint: string;
   pfxPath: string;
   subjectCN: string | null;
@@ -38,7 +42,12 @@ interface PsCandidate {
   notAfter: string;
 }
 
-interface PsSkipped {
+/**
+ * Shape of one entry in the PowerShell enumeration script's `skipped`
+ * array — a cert that matched the dev-cert OID but couldn't be exported
+ * (no private key, or key not exportable).
+ */
+export interface PsSkipped {
   thumbprint: string;
   subjectCN: string | null;
   notBefore: string;
@@ -46,7 +55,7 @@ interface PsSkipped {
   reason: string;
 }
 
-interface PsEnumeration {
+export interface PsEnumeration {
   candidates: PsCandidate[];
   skipped: PsSkipped[];
 }

--- a/src/vscode-ui-extension/tests/__mocks__/vscode.ts
+++ b/src/vscode-ui-extension/tests/__mocks__/vscode.ts
@@ -3,12 +3,13 @@
 
 export const warningMessages: string[] = [];
 export const errorMessages: string[] = [];
+export const logMessages: string[] = [];
 
 export const window = {
   createOutputChannel(_name: string) {
     return {
-      appendLine(_msg: string) {
-        // no-op in tests
+      appendLine(msg: string) {
+        logMessages.push(msg);
       },
     };
   },
@@ -41,6 +42,7 @@ export function __resetConfig() {
   }
   warningMessages.length = 0;
   errorMessages.length = 0;
+  logMessages.length = 0;
 }
 
 export const workspace = {

--- a/src/vscode-ui-extension/tests/classifyCandidate.test.ts
+++ b/src/vscode-ui-extension/tests/classifyCandidate.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { initLogger } from "@devcontainer-dev-certs/shared";
+import { logMessages } from "./__mocks__/vscode";
+import { classifyCandidate } from "../src/platform/baseStore";
+import { generateCertificate } from "../src/cert/generator";
+import { DevKey, DevCert } from "../src/cert/types";
+import { X509CertificateGenerator, cryptoProvider } from "@peculiar/x509";
+import { webcrypto } from "node:crypto";
+
+initLogger("test");
+
+cryptoProvider.set(webcrypto as unknown as Crypto);
+
+async function makeValidDevCert() {
+  const now = new Date();
+  const exp = new Date(now.getTime() + 365 * 86400 * 1000);
+  return generateCertificate(now, exp);
+}
+
+async function makeBogusLocalhostCert(): Promise<{
+  cert: DevCert;
+  key: DevKey;
+}> {
+  // Make a CN=localhost cert that LACKS the ASPNET_HTTPS_OID extension —
+  // not a dev cert per isValidDevCert, should classify as silent null.
+  const keyPair = await webcrypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"]
+  );
+  const now = new Date();
+  const exp = new Date(now.getTime() + 30 * 86400 * 1000);
+  const cert = await X509CertificateGenerator.create({
+    serialNumber: "01",
+    subject: "CN=localhost",
+    issuer: "CN=localhost",
+    notBefore: now,
+    notAfter: exp,
+    signingAlgorithm: { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    publicKey: keyPair.publicKey,
+    signingKey: keyPair.privateKey,
+    extensions: [],
+  });
+  return {
+    cert: new DevCert(cert),
+    key: await DevKey.fromCryptoKey(keyPair.privateKey),
+  };
+}
+
+describe("classifyCandidate", () => {
+  beforeEach(() => {
+    logMessages.length = 0;
+  });
+
+  it("returns usable for a valid cert + key (no log)", async () => {
+    const { cert, key, thumbprint } = await makeValidDevCert();
+    const result = classifyCandidate({
+      kind: "loaded",
+      source: "/path/to/file.pfx",
+      loaded: { cert, key, thumbprint },
+    });
+    expect(result?.kind).toBe("usable");
+    expect(logMessages).toHaveLength(0);
+  });
+
+  it("returns null silently for a cert that doesn't pass isValidDevCert", async () => {
+    const { cert, key } = await makeBogusLocalhostCert();
+    const result = classifyCandidate({
+      kind: "loaded",
+      source: "/path/to/file.pfx",
+      loaded: { cert, key, thumbprint: cert.thumbprintSha1 },
+    });
+    expect(result).toBeNull();
+    expect(logMessages).toHaveLength(0);
+  });
+
+  it("returns skipped + logs when a valid dev cert has no private key", async () => {
+    const { cert, thumbprint } = await makeValidDevCert();
+    const result = classifyCandidate({
+      kind: "loaded",
+      source: "/aspnet/dev-certs/https/aspnetcore-localhost-X.pfx",
+      loaded: { cert, key: null, thumbprint },
+    });
+    expect(result?.kind).toBe("skipped");
+    expect(logMessages).toHaveLength(1);
+    expect(logMessages[0]).toContain("certificate without matching private key");
+    expect(logMessages[0]).toContain(thumbprint);
+    expect(logMessages[0]).toContain("subjectCN=localhost");
+  });
+
+  it("returns skipped + logs on parse failure for canonical filenames", () => {
+    const result = classifyCandidate({
+      kind: "parseFailure",
+      source: "/aspnet/dev-certs/https/aspnetcore-localhost-ABCDEF.pfx",
+      thumbprintHint: "ABCDEF1234567890ABCDEF1234567890ABCDEF12",
+    });
+    expect(result?.kind).toBe("skipped");
+    expect(logMessages).toHaveLength(1);
+    expect(logMessages[0]).toContain("failed to parse PFX");
+  });
+
+  it("returns null silently on parse failure when no canonical thumbprint hint", () => {
+    const result = classifyCandidate({
+      kind: "parseFailure",
+      source: "/some/dir/random.pfx",
+      thumbprintHint: null,
+    });
+    expect(result).toBeNull();
+    expect(logMessages).toHaveLength(0);
+  });
+
+  it("returns skipped + logs for forcedSkip with metadata", () => {
+    const result = classifyCandidate({
+      kind: "forcedSkip",
+      source: "macOS login keychain",
+      reason: "present in keychain but no matching PFX on disk",
+      metadata: {
+        thumbprint: "ABC123",
+        subjectCN: "localhost",
+        version: 6,
+        notBefore: new Date("2026-01-01T00:00:00Z"),
+        notAfter: new Date("2027-01-01T00:00:00Z"),
+      },
+    });
+    expect(result?.kind).toBe("skipped");
+    expect(logMessages).toHaveLength(1);
+    expect(logMessages[0]).toContain("macOS login keychain");
+    expect(logMessages[0]).toContain("present in keychain");
+    expect(logMessages[0]).toContain("subjectCN=localhost");
+    expect(logMessages[0]).toContain("version=6");
+    expect(logMessages[0]).toContain("notBefore=2026-01-01T00:00:00.000Z");
+    expect(logMessages[0]).toContain("notAfter=2027-01-01T00:00:00.000Z");
+  });
+});

--- a/src/vscode-ui-extension/tests/linuxStore.test.ts
+++ b/src/vscode-ui-extension/tests/linuxStore.test.ts
@@ -3,9 +3,13 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import type * as Shared from "@devcontainer-dev-certs/shared";
+import { initLogger } from "@devcontainer-dev-certs/shared";
 import { generateCertificate } from "../src/cert/generator";
 import { VALIDITY_DAYS } from "../src/cert/properties";
-import { parsePfx } from "../src/cert/pfx";
+import { buildPfx, parsePfx } from "../src/cert/pfx";
+import { logMessages } from "./__mocks__/vscode";
+
+initLogger("test");
 
 // Mock runProcess so tests don't need an actual openssl binary.
 vi.mock("../src/platform/processUtil", () => ({
@@ -294,6 +298,54 @@ describe("LinuxCertificateStore", () => {
 
       const found = await store.findExistingDevCert();
       expect(found).toBeNull();
+    });
+
+    it("picks one of the candidates deterministically regardless of filename order", async () => {
+      const { cert: certA, key: keyA, thumbprint: thumbA } = await makeTestCert();
+      const { cert: certB, key: keyB, thumbprint: thumbB } = await makeTestCert();
+      const bytesA = await buildPfx({ cert: certA, key: keyA });
+      const bytesB = await buildPfx({ cert: certB, key: keyB });
+      fs.mkdirSync(testStoreDir, { recursive: true });
+      // Lexically reversed filenames so readdir order differs from
+      // selection order.
+      fs.writeFileSync(path.join(testStoreDir, `zzz-${thumbA}.pfx`), bytesA);
+      fs.writeFileSync(path.join(testStoreDir, `aaa-${thumbB}.pfx`), bytesB);
+
+      const found = await store.findExistingDevCert();
+      expect(found).not.toBeNull();
+      // Both certs share version; selection is deterministic on
+      // (version DESC, notAfter DESC).
+      expect([thumbA, thumbB]).toContain(found!.thumbprint);
+    });
+
+    it("warns when a canonically-named PFX fails to parse", async () => {
+      logMessages.length = 0;
+      const fakeThumb = "B".repeat(40);
+      fs.mkdirSync(testStoreDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(testStoreDir, `${fakeThumb}.pfx`),
+        Buffer.from("not a valid pfx")
+      );
+      await store.findExistingDevCert();
+      const warn = logMessages.find((m) => m.includes("failed to parse PFX"));
+      expect(warn).toBeDefined();
+      expect(warn).toContain(fakeThumb);
+    });
+
+    it("warns when a valid-looking PFX has no private key", async () => {
+      logMessages.length = 0;
+      const { cert, thumbprint } = await makeTestCert();
+      const bytes = await buildPfx({ cert }); // cert-only
+      fs.mkdirSync(testStoreDir, { recursive: true });
+      fs.writeFileSync(path.join(testStoreDir, `${thumbprint}.pfx`), bytes);
+
+      const found = await store.findExistingDevCert();
+      expect(found).toBeNull();
+      const warn = logMessages.find((m) =>
+        m.includes("certificate without matching private key")
+      );
+      expect(warn).toBeDefined();
+      expect(warn).toContain(thumbprint);
     });
   });
 

--- a/src/vscode-ui-extension/tests/macStore.test.ts
+++ b/src/vscode-ui-extension/tests/macStore.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { initLogger } from "@devcontainer-dev-certs/shared";
+import { logMessages } from "./__mocks__/vscode";
+import { generateCertificate } from "../src/cert/generator";
+import { VALIDITY_DAYS } from "../src/cert/properties";
+import { buildPfx } from "../src/cert/pfx";
+
+// Mock os.homedir so the macStore points at a writable temp dir.
+let testHomeDir = "";
+vi.mock("os", async (importOriginal) => {
+  const actual = await importOriginal<typeof os>();
+  return { ...actual, ...{ homedir: () => testHomeDir } };
+});
+
+// Mock runProcess so tests don't shell out to the real `security` CLI.
+vi.mock("../src/platform/processUtil", () => ({
+  runProcess: vi.fn(),
+}));
+
+import { MacCertificateStore } from "../src/platform/macStore";
+import { runProcess } from "../src/platform/processUtil";
+
+const mockedRunProcess = vi.mocked(runProcess);
+
+initLogger("test");
+
+async function makeTestCert(): ReturnType<typeof generateCertificate> {
+  const now = new Date();
+  const exp = new Date(now.getTime() + VALIDITY_DAYS * 86400 * 1000);
+  return generateCertificate(now, exp);
+}
+
+function devCertsDir(): string {
+  return path.join(testHomeDir, ".aspnet", "dev-certs", "https");
+}
+
+/**
+ * Build a security-CLI mock that:
+ *  - `find-certificate -Z <thumb>` succeeds for thumbprints in `keychainThumbs`
+ *  - `find-certificate -a -p -Z` returns a synthetic PEM block listing every
+ *    `extraKeychainPems` entry
+ *  - any other call resolves to a benign success
+ *  - tracks every command for assertions
+ */
+function setupSecurityMock(opts: {
+  keychainThumbs?: Set<string>;
+  extraKeychainPems?: string[];
+} = {}) {
+  const calls: Array<{ cmd: string; args: readonly string[] }> = [];
+  mockedRunProcess.mockImplementation(async (cmd: string, args: readonly string[]) => {
+    calls.push({ cmd, args: [...args] });
+    if (cmd !== "security") {
+      return { exitCode: 0, stdout: "", stderr: "" };
+    }
+    const sub = args[0];
+    if (sub === "find-certificate") {
+      // single-thumb lookup
+      if (args.includes("-Z") && !args.includes("-a")) {
+        const zIdx = args.indexOf("-Z");
+        const thumb = args[zIdx + 1];
+        const present = opts.keychainThumbs?.has(thumb) ?? false;
+        return {
+          exitCode: present ? 0 : 1,
+          stdout: present ? `SHA-1 hash: ${thumb}\n` : "",
+          stderr: present ? "" : "SecKeychainSearchCopyNext: The specified item could not be found",
+        };
+      }
+      // enumerate all
+      if (args.includes("-a") && args.includes("-p")) {
+        const pems = opts.extraKeychainPems ?? [];
+        return {
+          exitCode: 0,
+          stdout: pems.join("\n"),
+          stderr: "",
+        };
+      }
+    }
+    return { exitCode: 0, stdout: "", stderr: "" };
+  });
+  return {
+    calls,
+    securityExportCalled() {
+      return calls.some(
+        (c) => c.cmd === "security" && c.args[0] === "export"
+      );
+    },
+  };
+}
+
+describe("MacCertificateStore.findExistingDevCert", () => {
+  let store: MacCertificateStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logMessages.length = 0;
+    testHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "devcerts-mac-"));
+    fs.mkdirSync(devCertsDir(), { recursive: true });
+    store = new MacCertificateStore();
+  });
+
+  afterEach(() => {
+    fs.rmSync(testHomeDir, { recursive: true, force: true });
+  });
+
+  it("returns the cert when its thumbprint is present in the keychain", async () => {
+    const { cert, key, thumbprint } = await makeTestCert();
+    const pfxBytes = await buildPfx({ cert, key });
+    fs.writeFileSync(
+      path.join(devCertsDir(), `aspnetcore-localhost-${thumbprint}.pfx`),
+      pfxBytes
+    );
+
+    const sec = setupSecurityMock({ keychainThumbs: new Set([thumbprint]) });
+
+    const found = await store.findExistingDevCert();
+    expect(found?.thumbprint).toBe(thumbprint);
+    expect(sec.securityExportCalled()).toBe(false);
+  });
+
+  it("excludes a PFX whose cert is NOT in the keychain and logs the orphan warning", async () => {
+    const { cert, key, thumbprint } = await makeTestCert();
+    const pfxBytes = await buildPfx({ cert, key });
+    fs.writeFileSync(
+      path.join(devCertsDir(), `aspnetcore-localhost-${thumbprint}.pfx`),
+      pfxBytes
+    );
+
+    // Empty keychain — orphaned cache file.
+    const sec = setupSecurityMock({ keychainThumbs: new Set() });
+
+    const found = await store.findExistingDevCert();
+    expect(found).toBeNull();
+    expect(sec.securityExportCalled()).toBe(false);
+
+    const orphan = logMessages.find((m) => m.includes("orphaned cache file"));
+    expect(orphan).toBeDefined();
+    expect(orphan).toContain(thumbprint);
+  });
+
+  it("fires the keychain-only warning when a dev cert is in the keychain but not on disk", async () => {
+    const { cert } = await makeTestCert();
+    const pem = cert.pem;
+    const sec = setupSecurityMock({
+      keychainThumbs: new Set(),
+      extraKeychainPems: [pem],
+    });
+
+    const found = await store.findExistingDevCert();
+    expect(found).toBeNull();
+    expect(sec.securityExportCalled()).toBe(false);
+
+    const keychainOnly = logMessages.find((m) =>
+      m.includes("present in keychain but no matching PFX")
+    );
+    expect(keychainOnly).toBeDefined();
+    expect(keychainOnly).toContain(cert.thumbprintSha1);
+  });
+
+  it("does not warn about keychain certs that ARE represented on disk", async () => {
+    const { cert, key, thumbprint } = await makeTestCert();
+    const pfxBytes = await buildPfx({ cert, key });
+    fs.writeFileSync(
+      path.join(devCertsDir(), `aspnetcore-localhost-${thumbprint}.pfx`),
+      pfxBytes
+    );
+
+    const sec = setupSecurityMock({
+      keychainThumbs: new Set([thumbprint]),
+      extraKeychainPems: [cert.pem],
+    });
+
+    const found = await store.findExistingDevCert();
+    expect(found?.thumbprint).toBe(thumbprint);
+    expect(sec.securityExportCalled()).toBe(false);
+
+    const keychainOnly = logMessages.find((m) =>
+      m.includes("present in keychain but no matching PFX")
+    );
+    expect(keychainOnly).toBeUndefined();
+  });
+
+  it("never invokes `security export` (compliance regression)", async () => {
+    const { cert, key, thumbprint } = await makeTestCert();
+    const pfxBytes = await buildPfx({ cert, key });
+    fs.writeFileSync(
+      path.join(devCertsDir(), `aspnetcore-localhost-${thumbprint}.pfx`),
+      pfxBytes
+    );
+    const sec = setupSecurityMock({
+      keychainThumbs: new Set([thumbprint]),
+      extraKeychainPems: [cert.pem],
+    });
+
+    await store.findExistingDevCert();
+    expect(sec.securityExportCalled()).toBe(false);
+  });
+
+  it("warns and skips a cert-only PFX (no private key)", async () => {
+    const { cert, thumbprint } = await makeTestCert();
+    const pfxBytes = await buildPfx({ cert }); // no key
+    fs.writeFileSync(
+      path.join(devCertsDir(), `aspnetcore-localhost-${thumbprint}.pfx`),
+      pfxBytes
+    );
+    setupSecurityMock({ keychainThumbs: new Set([thumbprint]) });
+
+    const found = await store.findExistingDevCert();
+    expect(found).toBeNull();
+    const warn = logMessages.find((m) =>
+      m.includes("certificate without matching private key")
+    );
+    expect(warn).toBeDefined();
+  });
+
+  it("warns and skips an unparseable canonically-named PFX", async () => {
+    const fakeThumb = "A".repeat(40);
+    fs.writeFileSync(
+      path.join(devCertsDir(), `aspnetcore-localhost-${fakeThumb}.pfx`),
+      Buffer.from("not a real PFX")
+    );
+    setupSecurityMock({ keychainThumbs: new Set() });
+
+    const found = await store.findExistingDevCert();
+    expect(found).toBeNull();
+    const warn = logMessages.find((m) => m.includes("failed to parse PFX"));
+    expect(warn).toBeDefined();
+  });
+});

--- a/src/vscode-ui-extension/tests/selectBestDevCert.test.ts
+++ b/src/vscode-ui-extension/tests/selectBestDevCert.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { initLogger } from "@devcontainer-dev-certs/shared";
+import { logMessages } from "./__mocks__/vscode";
+import { selectBestDevCert, type UsableDevCert } from "../src/platform/baseStore";
+import { generateCertificate } from "../src/cert/generator";
+
+initLogger("test");
+
+async function makeCert(
+  notBefore: Date,
+  notAfter: Date
+): Promise<UsableDevCert> {
+  const { cert, key, thumbprint } = await generateCertificate(notBefore, notAfter);
+  return { cert, key, thumbprint };
+}
+
+describe("selectBestDevCert", () => {
+  beforeEach(() => {
+    logMessages.length = 0;
+  });
+
+  it("returns null for an empty list", () => {
+    const result = selectBestDevCert([], "test-ctx");
+    expect(result).toBeNull();
+    expect(logMessages).toHaveLength(0);
+  });
+
+  it("returns the single candidate without logging", async () => {
+    const now = new Date();
+    const exp = new Date(now.getTime() + 365 * 86400 * 1000);
+    const c = await makeCert(now, exp);
+    const result = selectBestDevCert([c], "test-ctx");
+    expect(result).toBe(c);
+    expect(logMessages).toHaveLength(0);
+  });
+
+  it("logs the multi-candidate warning when more than one candidate is present", async () => {
+    const now = new Date();
+    const expA = new Date(now.getTime() + 100 * 86400 * 1000);
+    const expB = new Date(now.getTime() + 200 * 86400 * 1000);
+    const a = await makeCert(now, expA);
+    const b = await makeCert(now, expB);
+
+    const result = selectBestDevCert([a, b], "Windows CurrentUser\\My");
+    // Both certs have the same (current) version — tiebreaker is later notAfter.
+    expect(result).toBe(b);
+
+    expect(logMessages).toHaveLength(1);
+    const msg = logMessages[0];
+    expect(msg).toContain("Multiple valid ASP.NET dev certs");
+    expect(msg).toContain("Windows CurrentUser\\My");
+    expect(msg).toContain(`selected ${b.thumbprint}`);
+    expect(msg).toContain("[selected]");
+    expect(msg).toContain("[skipped]");
+    expect(msg).toContain(`thumbprint=${b.thumbprint}`);
+    expect(msg).toContain(`thumbprint=${a.thumbprint}`);
+  });
+
+  it("picks the later notAfter when versions are equal", async () => {
+    const now = new Date();
+    const expA = new Date(now.getTime() + 50 * 86400 * 1000);
+    const expB = new Date(now.getTime() + 150 * 86400 * 1000);
+    const a = await makeCert(now, expA);
+    const b = await makeCert(now, expB);
+
+    expect(selectBestDevCert([a, b], "ctx")).toBe(b);
+    logMessages.length = 0;
+    expect(selectBestDevCert([b, a], "ctx")).toBe(b);
+  });
+
+  it("is deterministic regardless of input order", async () => {
+    const now = new Date();
+    const exp1 = new Date(now.getTime() + 100 * 86400 * 1000);
+    const exp2 = new Date(now.getTime() + 200 * 86400 * 1000);
+    const exp3 = new Date(now.getTime() + 300 * 86400 * 1000);
+    const c1 = await makeCert(now, exp1);
+    const c2 = await makeCert(now, exp2);
+    const c3 = await makeCert(now, exp3);
+
+    const orderings = [
+      [c1, c2, c3],
+      [c3, c2, c1],
+      [c2, c1, c3],
+      [c2, c3, c1],
+    ];
+    for (const ordering of orderings) {
+      const r = selectBestDevCert(ordering, "ctx");
+      expect(r).toBe(c3);
+    }
+  });
+});

--- a/src/vscode-ui-extension/tests/windowsStore.test.ts
+++ b/src/vscode-ui-extension/tests/windowsStore.test.ts
@@ -165,7 +165,7 @@ describe("WindowsCertificateStore.findExistingDevCert", () => {
           subjectCN: "localhost",
           notBefore: now.toISOString(),
           notAfter: exp.toISOString(),
-          reason: "private key not exportable (KeyExportPolicy=NonExportable)",
+          reason: "private key not exportable",
         },
         {
           // Expired — should NOT warn (silent skip).

--- a/src/vscode-ui-extension/tests/windowsStore.test.ts
+++ b/src/vscode-ui-extension/tests/windowsStore.test.ts
@@ -165,7 +165,7 @@ describe("WindowsCertificateStore.findExistingDevCert", () => {
           subjectCN: "localhost",
           notBefore: now.toISOString(),
           notAfter: exp.toISOString(),
-          reason: "private key not exportable",
+          reasonCode: "not-exportable",
         },
         {
           // Expired — should NOT warn (silent skip).
@@ -173,7 +173,7 @@ describe("WindowsCertificateStore.findExistingDevCert", () => {
           subjectCN: "localhost",
           notBefore: new Date(now.getTime() - 365 * 86400 * 1000).toISOString(),
           notAfter: new Date(now.getTime() - 1 * 86400 * 1000).toISOString(),
-          reason: "no private key in store",
+          reasonCode: "no-private-key",
         },
         {
           // Wrong CN — should NOT warn.
@@ -181,7 +181,7 @@ describe("WindowsCertificateStore.findExistingDevCert", () => {
           subjectCN: "other.example.com",
           notBefore: now.toISOString(),
           notAfter: exp.toISOString(),
-          reason: "no private key in store",
+          reasonCode: "no-private-key",
         },
       ],
     });
@@ -208,7 +208,7 @@ describe("WindowsCertificateStore.findExistingDevCert", () => {
           subjectCN: "localhost",
           notBefore: now.toISOString(),
           notAfter: exp.toISOString(),
-          reason: "private key not exportable",
+          reasonCode: "not-exportable",
         },
       ],
     });

--- a/src/vscode-ui-extension/tests/windowsStore.test.ts
+++ b/src/vscode-ui-extension/tests/windowsStore.test.ts
@@ -14,28 +14,16 @@ vi.mock("../src/platform/processUtil", () => ({
   runProcess: vi.fn(),
 }));
 
-import { WindowsCertificateStore } from "../src/platform/windowsStore";
+import {
+  WindowsCertificateStore,
+  type PsCandidate,
+  type PsSkipped,
+} from "../src/platform/windowsStore";
 import { runProcess } from "../src/platform/processUtil";
 
 const mockedRunProcess = vi.mocked(runProcess);
 
 initLogger("test");
-
-interface PsCandidate {
-  thumbprint: string;
-  pfxPath: string;
-  subjectCN: string;
-  notBefore: string;
-  notAfter: string;
-}
-
-interface PsSkipped {
-  thumbprint: string;
-  subjectCN: string;
-  notBefore: string;
-  notAfter: string;
-  reason: string;
-}
 
 /**
  * Wire `runProcess` to behave like PowerShell:

--- a/src/vscode-ui-extension/tests/windowsStore.test.ts
+++ b/src/vscode-ui-extension/tests/windowsStore.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { initLogger } from "@devcontainer-dev-certs/shared";
+import { logMessages } from "./__mocks__/vscode";
+import { generateCertificate } from "../src/cert/generator";
+import { VALIDITY_DAYS } from "../src/cert/properties";
+import { buildPfx } from "../src/cert/pfx";
+import { type DevCert, type DevKey } from "../src/cert/types";
+
+
+vi.mock("../src/platform/processUtil", () => ({
+  runProcess: vi.fn(),
+}));
+
+import { WindowsCertificateStore } from "../src/platform/windowsStore";
+import { runProcess } from "../src/platform/processUtil";
+
+const mockedRunProcess = vi.mocked(runProcess);
+
+initLogger("test");
+
+interface PsCandidate {
+  thumbprint: string;
+  pfxPath: string;
+  subjectCN: string;
+  notBefore: string;
+  notAfter: string;
+}
+
+interface PsSkipped {
+  thumbprint: string;
+  subjectCN: string;
+  notBefore: string;
+  notAfter: string;
+  reason: string;
+}
+
+/**
+ * Wire `runProcess` to behave like PowerShell:
+ *  - First call (the pwsh-presence probe) succeeds with 'ok'.
+ *  - Subsequent calls return the supplied enumeration JSON.
+ *
+ * Returns the temp PFXs so individual tests can assert they're unlinked.
+ */
+function setupPsMock(opts: {
+  candidates?: PsCandidate[];
+  skipped?: PsSkipped[];
+}) {
+  let psProbed = false;
+  mockedRunProcess.mockImplementation(async (cmd: string, args: readonly string[]) => {
+    if (cmd === "pwsh" && args.includes("echo ok") && !psProbed) {
+      psProbed = true;
+      return { exitCode: 0, stdout: "ok", stderr: "" };
+    }
+    // Enumeration call — script is the last arg.
+    const payload = {
+      candidates: opts.candidates ?? [],
+      skipped: opts.skipped ?? [],
+    };
+    return {
+      exitCode: 0,
+      stdout: JSON.stringify(payload),
+      stderr: "",
+    };
+  });
+}
+
+describe("WindowsCertificateStore.findExistingDevCert", () => {
+  let store: WindowsCertificateStore;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Each test instantiates a fresh store, but module-level resolvedPwsh
+    // caches between tests. The pwsh probe is short-circuited by setupPsMock.
+    logMessages.length = 0;
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "devcerts-win-"));
+    store = new WindowsCertificateStore("CurrentUser");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeExportablePfx(opts: {
+    notAfter?: Date;
+  } = {}): Promise<{
+    cert: DevCert;
+    key: DevKey;
+    thumbprint: string;
+    pfxPath: string;
+    notBefore: Date;
+    notAfter: Date;
+  }> {
+    const now = new Date();
+    const exp = opts.notAfter ?? new Date(now.getTime() + VALIDITY_DAYS * 86400 * 1000);
+    const generated = await generateCertificate(now, exp);
+    const pfxBytes = await buildPfx({
+      cert: generated.cert,
+      key: generated.key,
+      password: "export",
+    });
+    const pfxPath = path.join(tmpDir, `${generated.thumbprint}.pfx`);
+    fs.writeFileSync(pfxPath, pfxBytes);
+    return { ...generated, pfxPath, notBefore: now, notAfter: exp };
+  }
+
+  it("returns the cert when a single candidate is present", async () => {
+    const c = await writeExportablePfx();
+    setupPsMock({
+      candidates: [
+        {
+          thumbprint: c.thumbprint,
+          pfxPath: c.pfxPath,
+          subjectCN: "localhost",
+          notBefore: c.notBefore.toISOString(),
+          notAfter: c.notAfter.toISOString(),
+        },
+      ],
+    });
+
+    const found = await store.findExistingDevCert();
+    expect(found?.thumbprint).toBe(c.thumbprint);
+    expect(fs.existsSync(c.pfxPath)).toBe(false); // temp cleaned up
+  });
+
+  it("picks the cert with the later notAfter when versions are equal", async () => {
+    const a = await writeExportablePfx({
+      notAfter: new Date(Date.now() + 100 * 86400 * 1000),
+    });
+    const b = await writeExportablePfx({
+      notAfter: new Date(Date.now() + 300 * 86400 * 1000),
+    });
+    const winner = b; // later notAfter wins on equal version
+    setupPsMock({
+      candidates: [a, b].map((c) => ({
+        thumbprint: c.thumbprint,
+        pfxPath: c.pfxPath,
+        subjectCN: "localhost",
+        notBefore: c.notBefore.toISOString(),
+        notAfter: c.notAfter.toISOString(),
+      })),
+    });
+
+    const found = await store.findExistingDevCert();
+    expect(found?.thumbprint).toBe(winner.thumbprint);
+    // Selection log should have fired.
+    const sel = logMessages.find((m) =>
+      m.includes("Multiple valid ASP.NET dev certs")
+    );
+    expect(sel).toBeDefined();
+    expect(sel).toContain("Windows CurrentUser\\My");
+    // Both temp PFXs cleaned up.
+    expect(fs.existsSync(a.pfxPath)).toBe(false);
+    expect(fs.existsSync(b.pfxPath)).toBe(false);
+  });
+
+  it("logs unusable warnings for skipped[] entries that look like dev certs", async () => {
+    const c = await writeExportablePfx();
+    const now = new Date();
+    const exp = new Date(now.getTime() + 100 * 86400 * 1000);
+    setupPsMock({
+      candidates: [
+        {
+          thumbprint: c.thumbprint,
+          pfxPath: c.pfxPath,
+          subjectCN: "localhost",
+          notBefore: c.notBefore.toISOString(),
+          notAfter: c.notAfter.toISOString(),
+        },
+      ],
+      skipped: [
+        {
+          thumbprint: "DEADBEEF",
+          subjectCN: "localhost",
+          notBefore: now.toISOString(),
+          notAfter: exp.toISOString(),
+          reason: "private key not exportable (KeyExportPolicy=NonExportable)",
+        },
+        {
+          // Expired — should NOT warn (silent skip).
+          thumbprint: "CAFE0000",
+          subjectCN: "localhost",
+          notBefore: new Date(now.getTime() - 365 * 86400 * 1000).toISOString(),
+          notAfter: new Date(now.getTime() - 1 * 86400 * 1000).toISOString(),
+          reason: "no private key in store",
+        },
+        {
+          // Wrong CN — should NOT warn.
+          thumbprint: "BEEF0000",
+          subjectCN: "other.example.com",
+          notBefore: now.toISOString(),
+          notAfter: exp.toISOString(),
+          reason: "no private key in store",
+        },
+      ],
+    });
+
+    const found = await store.findExistingDevCert();
+    expect(found?.thumbprint).toBe(c.thumbprint);
+
+    const unusable = logMessages.filter((m) =>
+      m.includes("Skipping ASP.NET dev cert")
+    );
+    expect(unusable).toHaveLength(1);
+    expect(unusable[0]).toContain("DEADBEEF");
+    expect(unusable[0]).toContain("not exportable");
+  });
+
+  it("returns null when only skipped[] entries exist", async () => {
+    const now = new Date();
+    const exp = new Date(now.getTime() + 100 * 86400 * 1000);
+    setupPsMock({
+      candidates: [],
+      skipped: [
+        {
+          thumbprint: "DEADBEEF",
+          subjectCN: "localhost",
+          notBefore: now.toISOString(),
+          notAfter: exp.toISOString(),
+          reason: "private key not exportable",
+        },
+      ],
+    });
+
+    const found = await store.findExistingDevCert();
+    expect(found).toBeNull();
+
+    const unusable = logMessages.filter((m) =>
+      m.includes("Skipping ASP.NET dev cert")
+    );
+    expect(unusable).toHaveLength(1);
+  });
+
+  it("cleans up temp PFXs even when no candidate is selected", async () => {
+    // Build a candidate that points at a nonexistent file — load will fail.
+    setupPsMock({
+      candidates: [
+        {
+          thumbprint: "ABC123",
+          pfxPath: path.join(tmpDir, "nonexistent.pfx"),
+          subjectCN: "localhost",
+          notBefore: new Date().toISOString(),
+          notAfter: new Date(Date.now() + 86400 * 1000).toISOString(),
+        },
+      ],
+    });
+
+    const found = await store.findExistingDevCert();
+    expect(found).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

This PR refactors the dev certificate discovery and selection logic across all platforms (Windows, macOS, Linux) to use a unified classification and ranking system. Instead of each platform independently finding and returning a single "best" cert, they now enumerate all candidates, classify them as usable/skipped, and delegate selection to shared logic that ranks by version and expiration date.

## Key Changes

- **New classification system in `baseStore.ts`**:
  - `classifyCandidate()`: Categorizes a single cert candidate as `usable`, `skipped` (with diagnostic warning), or `null` (silent rejection for non-dev-certs)
  - `selectBestDevCert()`: Ranks usable candidates by version (descending) then `notAfter` (descending), mirrors .NET's `dotnet dev-certs` behavior
  - `extractThumbprintHintFromFilename()`: Extracts SHA-1 thumbprint from canonical PFX filenames
  - Comprehensive logging for skipped candidates with metadata (CN, version, validity window)

- **Windows store (`windowsStore.ts`)**:
  - PowerShell script now enumerates ALL certs with the ASP.NET OID, attempts export for each, and returns both successful candidates and failed exports
  - Classifies export failures (non-exportable keys, parse errors) as skipped with detailed reasons
  - Filters skipped entries through `isValidDevCert` gates to avoid warnings for unrelated certs
  - Delegates selection to `selectBestDevCert()`

- **macOS store (`macStore.ts`)**:
  - Scans `~/.aspnet/dev-certs/https/` for PFX files and verifies each cert is present in login keychain via `security find-certificate -Z` (public-only, no prompts)
  - Classifies orphaned cache files (PFX on disk but cert not in keychain) as skipped
  - Enumerates keychain-resident dev certs and warns about keychain-only entries lacking a cache PFX
  - Never invokes `security export` (compliance requirement)
  - Delegates selection to `selectBestDevCert()`

- **Linux store (`linuxStore.ts`)**:
  - Refactored to use new classification system for consistency
  - Now deterministically selects among multiple candidates

- **New helper methods in `BaseCertificateStore`**:
  - `loadPfxLenient()`: Parses PFX and returns cert + key (key may be null), returns null only on parse failure
  - `loadPfx()`: Strict variant that requires both cert and key, returns null if either is missing

## Notable Implementation Details

- **Diagnostic logging**: Skipped candidates emit a single human-readable warning at classification time with full metadata (thumbprint, CN, version, validity window), surfacing before selection happens
- **Multi-candidate selection warning**: When multiple usable candidates exist, a single consolidated warning lists all candidates with their versions and validity windows, showing which was selected
- **Silent rejections**: Certs that fail `isValidDevCert` (wrong CN, expired, missing OID, old version) are silently rejected with no log — users can't act on these
- **Deterministic selection**: Sorting by version DESC then notAfter DESC ensures consistent behavior across platforms and input orders
- **Comprehensive test coverage**: New test suites for `classifyCandidate()`, `selectBestDevCert()`, Windows store, and macOS store enumerate edge cases (orphaned files, keychain-only certs, parse failures, non-exportable keys)

https://claude.ai/code/session_019j5yqsghFHPj3diU6AwCMZ