### PR TITLE
Release version 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7075,7 +7075,7 @@
     },
     "src/shared": {
       "name": "@devcontainer-dev-certs/shared",
-      "version": "1.1.1-pre",
+      "version": "1.2.0",
       "devDependencies": {
         "@types/vscode": "^1.100.0",
         "typescript": "^6.0.3"
@@ -7083,7 +7083,7 @@
     },
     "src/vscode-ui-extension": {
       "name": "devcontainer-dev-certs-host",
-      "version": "1.1.1-pre",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@devcontainer-dev-certs/shared": "*",
@@ -7106,7 +7106,7 @@
     },
     "src/vscode-workspace-extension": {
       "name": "devcontainer-dev-certs-remote",
-      "version": "1.1.1-pre",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@devcontainer-dev-certs/shared": "*"

--- a/src/devcontainer-feature/src/devcontainer-dev-certs/devcontainer-feature.json
+++ b/src/devcontainer-feature/src/devcontainer-dev-certs/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "devcontainer-dev-certs",
-  "version": "1.1.1-pre",
+  "version": "1.2.0",
   "name": "Dev Container Development Certificates",
   "description": "Enables trusted HTTPS in Dev Containers by preparing certificate trust infrastructure and installing companion VS Code extensions that automatically generate, trust, and transfer ASP.NET and Aspire compatible development certificates from the host machine. Add to your devcontainer.json: \"features\": { \"ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs:1\": {} }",
   "documentationURL": "https://github.com/dnegstad/devcontainer-dev-certs",

--- a/src/shared/package.json
+++ b/src/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devcontainer-dev-certs/shared",
-  "version": "1.1.1-pre",
+  "version": "1.2.0",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/src/vscode-ui-extension/package.json
+++ b/src/vscode-ui-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Dev Container Dev Certificates (Host)",
   "description": "Generates and trusts ASP.NET and Aspire compatible HTTPS development certificates on the host machine for use in Dev Containers and remote environments.",
   "icon": "images/dn_ui_extension_icon_256.png",
-  "version": "1.1.1-pre",
+  "version": "1.2.0",
   "publisher": "dnegstad",
   "license": "MIT",
   "repository": {

--- a/src/vscode-workspace-extension/package.json
+++ b/src/vscode-workspace-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Dev Container Dev Certificates (Remote)",
   "description": "Receives and installs ASP.NET and Aspire compatible HTTPS development certificates inside Dev Containers and remote environments.",
   "icon": "images/dn_workspace_extension_icon_256.png",
-  "version": "1.1.1-pre",
+  "version": "1.2.0",
   "publisher": "dnegstad",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
This release bumps the version from 1.1.1-pre to 1.2.0 across all packages and components in the devcontainer-dev-certs project.

## Changes
- Updated devcontainer feature version to 1.2.0
- Updated shared package version to 1.2.0
- Updated VS Code UI extension version to 1.2.0
- Updated VS Code workspace extension version to 1.2.0

This is a coordinated version bump across all components to maintain consistency and prepare for the 1.2.0 release.

https://claude.ai/code/session_01QV23MbiqRVN8VdzpS5Dy5z