### PR TITLE
Release version 1.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7112,7 +7112,7 @@
     },
     "src/shared": {
       "name": "@devcontainer-dev-certs/shared",
-      "version": "1.3.2-pre",
+      "version": "1.3.2",
       "dependencies": {
         "@peculiar/x509": "^2.0.0",
         "asn1js": "^3.0.10",
@@ -7125,7 +7125,7 @@
     },
     "src/vscode-ui-extension": {
       "name": "devcontainer-dev-certs-host",
-      "version": "1.3.2-pre",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@devcontainer-dev-certs/shared": "*",
@@ -7148,7 +7148,7 @@
     },
     "src/vscode-workspace-extension": {
       "name": "devcontainer-dev-certs-remote",
-      "version": "1.3.2-pre",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@devcontainer-dev-certs/shared": "*",

--- a/src/devcontainer-feature/src/devcontainer-dev-certs/devcontainer-feature.json
+++ b/src/devcontainer-feature/src/devcontainer-dev-certs/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "devcontainer-dev-certs",
-  "version": "1.3.2-pre",
+  "version": "1.3.2",
   "name": "Dev Container Development Certificates",
   "description": "Enables trusted HTTPS in Dev Containers by preparing certificate trust infrastructure and installing companion VS Code extensions that automatically generate, trust, and transfer ASP.NET and Aspire compatible development certificates from the host machine. Add to your devcontainer.json: \"features\": { \"ghcr.io/dnegstad/devcontainer-dev-certs/devcontainer-dev-certs:1\": {} }",
   "documentationURL": "https://github.com/dnegstad/devcontainer-dev-certs",

--- a/src/shared/package.json
+++ b/src/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devcontainer-dev-certs/shared",
-  "version": "1.3.2-pre",
+  "version": "1.3.2",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/src/vscode-ui-extension/package.json
+++ b/src/vscode-ui-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Dev Container Dev Certificates (Host)",
   "description": "Generates and trusts ASP.NET and Aspire compatible HTTPS development certificates on the host machine for use in Dev Containers and remote environments.",
   "icon": "images/dn_ui_extension_icon_256.png",
-  "version": "1.3.2-pre",
+  "version": "1.3.2",
   "publisher": "dnegstad",
   "license": "MIT",
   "repository": {

--- a/src/vscode-workspace-extension/package.json
+++ b/src/vscode-workspace-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Dev Container Dev Certificates (Remote)",
   "description": "Receives and installs ASP.NET and Aspire compatible HTTPS development certificates inside Dev Containers and remote environments.",
   "icon": "images/dn_workspace_extension_icon_256.png",
-  "version": "1.3.2-pre",
+  "version": "1.3.2",
   "publisher": "dnegstad",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
This release promotes version 1.3.2 from pre-release to stable across all packages and extensions in the devcontainer-dev-certs project.

## Changes
- Updated version from `1.3.2-pre` to `1.3.2` in:
  - DevContainer feature manifest (`devcontainer-feature.json`)
  - Shared package (`src/shared/package.json`)
  - VS Code Host UI extension (`src/vscode-ui-extension/package.json`)
  - VS Code Remote/Workspace extension (`src/vscode-workspace-extension/package.json`)

## Details
This is a version bump to release the stable 1.3.2 version of the devcontainer-dev-certs feature and its associated VS Code extensions. All components are synchronized to the same version number.

https://claude.ai/code/session_016Fvxuqvi9VJa8UDt68h4QX